### PR TITLE
Fix angular brackets around datatype IRIs

### DIFF
--- a/hdt-lib/src/rdf/RDFParserRaptorCallback.cpp
+++ b/hdt-lib/src/rdf/RDFParserRaptorCallback.cpp
@@ -26,8 +26,9 @@ string getString(raptor_term *term) {
 			out.append("\"");
 		}
 		if(term->value.literal.datatype) {
-			out.append("^^");
+			out.append("^^<");
 			out.append((char *)raptor_uri_as_string(term->value.literal.datatype));
+			out.append(">");
 		}
 	} else if(term->type==RAPTOR_TERM_TYPE_BLANK) {
 		out.append((char *)term->value.blank.string);

--- a/hdt-lib/src/rdf/RDFParserSerd.cpp
+++ b/hdt-lib/src/rdf/RDFParserSerd.cpp
@@ -44,8 +44,9 @@ string RDFParserSerd::getStringObject(const SerdNode *term, const SerdNode *data
         out.append("\"");
     }
     if(dataType!=NULL) {
-        out.append("^^");
+        out.append("^^<");
         out.append((char *)dataType->buf);
+        out.append(">");
     }
 
     //cout << out << endl;


### PR DESCRIPTION
When HDT files are generated with the built-in NTriple parser, [angular brackets surrounding a literal's type IRI become part of that literal](https://github.com/rdfhdt/hdt-cpp/blob/78a41e0c667230b5dbd40ab7f2bce998e2ad9a9e/hdt-lib/src/rdf/RDFParserNtriples.cpp#L99-L101). This means this parser encodes a literal as follows:

```
"literal"^^<http://example.org/type>
```

However, the current Raptor and Serd implementations do not have this behavior, and encode as follows:

```
"literal"^^http://example.org/type
```

This pull request corrects this behavior so all parsers use angular brackets around datatype IRIs.

If the opposite behavior is desired, please let me know and I'll update this pull request.
