### PR TITLE
Fix reading of empty HDT files

### DIFF
--- a/hdt-lib/src/bitsequence/BitSequence375.h
+++ b/hdt-lib/src/bitsequence/BitSequence375.h
@@ -88,7 +88,7 @@ private:
 	}
 
 	inline size_t numBytes(size_t bits) const {
-		return ((bits-1)>>3) + 1;
+		return bits==0 ? 1 : ((bits-1)>>3) + 1;
 	}
 
 	inline size_t numWords(size_t bits) const {

--- a/hdt-lib/src/triples/BitmapTriples.cpp
+++ b/hdt-lib/src/triples/BitmapTriples.cpp
@@ -280,7 +280,8 @@ void BitmapTriples::generateIndexMemory(ProgressListener *listener) {
 		bitmapIndex->set(tmpCount-1, true);
 		NOTIFYCOND3(&iListener, "Creating Index bitmap", i, objectCount->getNumberOfElements(), 1000000);
 	}
-	bitmapIndex->set(arrayZ->getNumberOfElements()-1, true);
+	if (arrayZ->getNumberOfElements())
+	  bitmapIndex->set(arrayZ->getNumberOfElements()-1, true);
 	delete objectCount;
 	objectCount=NULL;
 	cout << "Bitmap in " << st << endl;

--- a/hdt-lib/src/triples/predicateindex.cpp
+++ b/hdt-lib/src/triples/predicateindex.cpp
@@ -107,7 +107,8 @@ void PredicateIndexArray::generate(ProgressListener *listener) {
         bitmap->set(tempCountPred-1, true);
         NOTIFYCOND3(&iListener, "Creating Predicate bitmap", i, predCount->getNumberOfElements(), 100000);
     }
-    bitmap->set(triples->arrayY->getNumberOfElements()-1, true);
+    if(triples->arrayY->getNumberOfElements())
+        bitmap->set(triples->arrayY->getNumberOfElements()-1, true);
     cout << "Predicate Bitmap in " << st << endl;
     st.reset();
 


### PR DESCRIPTION
As reported on LinkedDataFragments/Server.js#13, reading an empty HDT file causes an error.

After investigation, I found error to be related to index generation. Furthermore, another bug occurred when subsequently reading the generated index file. This pull request fixes both bugs.