### PR TITLE
Fix header files includes

### DIFF
--- a/hdt-lib/include/ControlInformation.hpp
+++ b/hdt-lib/include/ControlInformation.hpp
@@ -29,8 +29,8 @@
  *
  */
 
-#ifndef CONTROLINFORMATION_H_
-#define CONTROLINFORMATION_H_
+#ifndef HDT_CONTROLINFORMATION_HPP_
+#define HDT_CONTROLINFORMATION_HPP_
 
 #include <stdint.h>
 #include <iostream>
@@ -126,4 +126,4 @@ public:
 
 }
 
-#endif /* CONTROLINFORMATION_H_ */
+#endif /* HDT_CONTROLINFORMATION_HPP_ */

--- a/hdt-lib/include/Dictionary.hpp
+++ b/hdt-lib/include/Dictionary.hpp
@@ -29,8 +29,8 @@
  *
  */
 
-#ifndef HDT_DICTIONARY_
-#define HDT_DICTIONARY_
+#ifndef HDT_DICTIONARY_HPP_
+#define HDT_DICTIONARY_HPP_
 
 #include "HDTListener.hpp"
 #include "SingleTriple.hpp"
@@ -195,4 +195,4 @@ public:
 
 }
 
-#endif  /* HDT_DICTIONARY_ */
+#endif /* HDT_DICTIONARY_HPP_ */

--- a/hdt-lib/include/Dictionary.hpp
+++ b/hdt-lib/include/Dictionary.hpp
@@ -32,16 +32,16 @@
 #ifndef HDT_DICTIONARY_
 #define HDT_DICTIONARY_
 
+#include "HDTListener.hpp"
+#include "SingleTriple.hpp"
+#include "Iterator.hpp"
+#include "HDTEnums.hpp"
+#include "Header.hpp"
+#include "ControlInformation.hpp"
+#include "Triples.hpp"
+
 #include <string>
 #include <iostream>
-
-#include <HDTListener.hpp>
-#include <SingleTriple.hpp>
-#include <Iterator.hpp>
-#include <HDTEnums.hpp>
-#include <Header.hpp>
-#include <ControlInformation.hpp>
-#include <Triples.hpp>
 
 namespace hdt {
 

--- a/hdt-lib/include/Dictionary.hpp
+++ b/hdt-lib/include/Dictionary.hpp
@@ -172,9 +172,7 @@ public:
 
 class ModifiableDictionary : public Dictionary {
 public:
-	virtual ~ModifiableDictionary(){
-
-	}
+	virtual ~ModifiableDictionary(){ }
 
     /**
     * Insert a new entry to the dictionary in the corresponding section according to the role (Subject, Predicate, Object).
@@ -196,6 +194,5 @@ public:
 };
 
 }
-
 
 #endif  /* HDT_DICTIONARY_ */

--- a/hdt-lib/include/HDT.hpp
+++ b/hdt-lib/include/HDT.hpp
@@ -33,15 +33,15 @@
 #ifndef HDT_
 #define HDT_
 
-#include <RDF.hpp>
-#include <HDTSpecification.hpp>
-#include <HDTEnums.hpp>
-#include <HDTListener.hpp>
-#include <Header.hpp>
-#include <Dictionary.hpp>
-#include <Triples.hpp>
-#include <RDFParser.hpp>
-#include <RDFSerializer.hpp>
+#include "RDF.hpp"
+#include "HDTSpecification.hpp"
+#include "HDTEnums.hpp"
+#include "HDTListener.hpp"
+#include "Header.hpp"
+#include "Dictionary.hpp"
+#include "Triples.hpp"
+#include "RDFParser.hpp"
+#include "RDFSerializer.hpp"
 
 #include <iostream>
 #include <set>

--- a/hdt-lib/include/HDT.hpp
+++ b/hdt-lib/include/HDT.hpp
@@ -29,7 +29,6 @@
  *
  */
 
-
 #ifndef HDT_
 #define HDT_
 
@@ -48,7 +47,6 @@
 
 namespace hdt {
 
-
 /**
  * Main HDT class. Represents an abstract access to a HDT object.
  * It provides methods to get the Dictionary, Header and Triples.
@@ -57,7 +55,6 @@ namespace hdt {
 class HDT : public RDFAccess
 {
 public:
-
 	virtual ~HDT() { };
 
 	/**
@@ -114,14 +111,12 @@ public:
     virtual bool isIndexed()=0;
 };
 
-
 /**
  * ModifiableHDT is a HDT that provides read/write operations. In addition to read operations,
  * it allows to insert and remove triples.
  */
 class ModifiableHDT : public HDT {
 public:
-
 	virtual ~ModifiableHDT(){ }
 
 	/**

--- a/hdt-lib/include/HDT.hpp
+++ b/hdt-lib/include/HDT.hpp
@@ -29,8 +29,8 @@
  *
  */
 
-#ifndef HDT_
-#define HDT_
+#ifndef HDT_HDT_HPP_
+#define HDT_HDT_HPP_
 
 #include "RDF.hpp"
 #include "HDTSpecification.hpp"
@@ -148,4 +148,4 @@ public:
 
 }
 
-#endif /* HDT_ */
+#endif /* HDT_HDT_HPP_ */

--- a/hdt-lib/include/HDTEnums.hpp
+++ b/hdt-lib/include/HDTEnums.hpp
@@ -29,8 +29,8 @@
  *
  */
 
-#ifndef HDT_ENUMS_
-#define HDT_ENUMS_
+#ifndef HDT_HDTENUMS_HPP_
+#define HDT_HDTENUMS_HPP_
 
 #include <string.h>
 
@@ -149,4 +149,4 @@ enum ResultEstimationType {
 
 }
 
-#endif
+#endif /* HDT_HDTENUMS_HPP_ */

--- a/hdt-lib/include/HDTListener.hpp
+++ b/hdt-lib/include/HDTListener.hpp
@@ -29,8 +29,8 @@
  *
  */
 
-#ifndef HDTLISTENER_HPP_
-#define HDTLISTENER_HPP_
+#ifndef HDT_HDTLISTENER_HPP_
+#define HDT_HDTLISTENER_HPP_
 
 #include <iostream>
 #include <iomanip>
@@ -109,4 +109,4 @@ public:
 
 }
 
-#endif /* HDTLISTENER_HPP_ */
+#endif /* HDT_HDTLISTENER_HPP_ */

--- a/hdt-lib/include/HDTListener.hpp
+++ b/hdt-lib/include/HDTListener.hpp
@@ -29,7 +29,6 @@
  *
  */
 
-
 #ifndef HDTLISTENER_HPP_
 #define HDTLISTENER_HPP_
 
@@ -79,7 +78,6 @@ public:
 	}
 };
 
-
 class StdoutProgressListener : public ProgressListener {
 private:
 public:
@@ -110,6 +108,5 @@ public:
     if((listener)!=NULL && total!=0 && ((counter)%(step)) == 0) (listener)->notifyProgress( ((counter)*100.0/(total)), (message));
 
 }
-
 
 #endif /* HDTLISTENER_HPP_ */

--- a/hdt-lib/include/HDTManager.hpp
+++ b/hdt-lib/include/HDTManager.hpp
@@ -32,9 +32,10 @@
 #ifndef HDT_MANAGER_
 #define HDT_MANAGER_
 
-#include <HDTSpecification.hpp>
-#include <HDT.hpp>
-#include <HDTListener.hpp>
+#include "HDTSpecification.hpp"
+#include "HDT.hpp"
+#include "HDTListener.hpp"
+
 #include <string>
 
 namespace hdt {

--- a/hdt-lib/include/HDTManager.hpp
+++ b/hdt-lib/include/HDTManager.hpp
@@ -29,8 +29,8 @@
  *
  */
 
-#ifndef HDT_MANAGER_
-#define HDT_MANAGER_
+#ifndef HDT_HDTMANAGER_HPP_
+#define HDT_HDTMANAGER_HPP_
 
 #include "HDTSpecification.hpp"
 #include "HDT.hpp"
@@ -93,4 +93,4 @@ public:
 };
 }
 
-#endif
+#endif /* HDT_HDTMANAGER_HPP_ */

--- a/hdt-lib/include/HDTManager.hpp
+++ b/hdt-lib/include/HDTManager.hpp
@@ -94,5 +94,3 @@ public:
 }
 
 #endif
-
-

--- a/hdt-lib/include/HDTSpecification.hpp
+++ b/hdt-lib/include/HDTSpecification.hpp
@@ -29,8 +29,8 @@
  *
  */
 
-#ifndef HDTSPECIFICATION_
-#define HDTSPECIFICATION_
+#ifndef HDT_HDTSPECIFICATION_HPP_
+#define HDT_HDTSPECIFICATION_HPP_
 
 #include <string>
 #include <map>
@@ -74,4 +74,4 @@ public:
 
 }
 
-#endif /* HDTSPECIFICATION_ */
+#endif /* HDT_HDTSPECIFICATION_HPP_ */

--- a/hdt-lib/include/HDTSpecification.hpp
+++ b/hdt-lib/include/HDTSpecification.hpp
@@ -29,7 +29,6 @@
  *
  */
 
-
 #ifndef HDTSPECIFICATION_
 #define HDTSPECIFICATION_
 

--- a/hdt-lib/include/HDTVocabulary.hpp
+++ b/hdt-lib/include/HDTVocabulary.hpp
@@ -29,8 +29,8 @@
  *
  */
 
-#ifndef HDTVOCABULARY_HPP_
-#define HDTVOCABULARY_HPP_
+#ifndef HDT_HDTVOCABULARY_HPP_
+#define HDT_HDTVOCABULARY_HPP_
 
 #include <string>
 
@@ -131,4 +131,4 @@ namespace HDTVocabulary {
 }
 }
 
-#endif /* HDTVOCABULARY_HPP_ */
+#endif /* HDT_HDTVOCABULARY_HPP_ */

--- a/hdt-lib/include/HDTVocabulary.hpp
+++ b/hdt-lib/include/HDTVocabulary.hpp
@@ -29,7 +29,6 @@
  *
  */
 
-
 #ifndef HDTVOCABULARY_HPP_
 #define HDTVOCABULARY_HPP_
 
@@ -131,6 +130,5 @@ namespace HDTVocabulary {
 	const std::string HDT_SIZE = HDT_BASE+"hdtSize>";
 }
 }
-
 
 #endif /* HDTVOCABULARY_HPP_ */

--- a/hdt-lib/include/Header.hpp
+++ b/hdt-lib/include/Header.hpp
@@ -29,7 +29,6 @@
  *
  */
 
-
 #ifndef HEADER_
 #define HEADER_
 

--- a/hdt-lib/include/Header.hpp
+++ b/hdt-lib/include/Header.hpp
@@ -29,8 +29,8 @@
  *
  */
 
-#ifndef HEADER_
-#define HEADER_
+#ifndef HDT_HEADER_HPP_
+#define HDT_HEADER_HPP_
 
 #include "RDF.hpp"
 #include "ControlInformation.hpp"
@@ -179,4 +179,4 @@ public:
 
 }
 
-#endif /* HEADER_HPP_ */
+#endif /* HDT_HEADER_HPP_ */

--- a/hdt-lib/include/Header.hpp
+++ b/hdt-lib/include/Header.hpp
@@ -33,11 +33,12 @@
 #ifndef HEADER_
 #define HEADER_
 
-#include <RDF.hpp>
-#include <ControlInformation.hpp>
+#include "RDF.hpp"
+#include "ControlInformation.hpp"
+#include "HDTListener.hpp"
+
 #include <iostream>
 #include <sstream>
-#include <HDTListener.hpp>
 
 namespace hdt {
 

--- a/hdt-lib/include/Iterator.hpp
+++ b/hdt-lib/include/Iterator.hpp
@@ -29,8 +29,8 @@
  *
  */
 
-#ifndef ITERATOR_HPP_
-#define ITERATOR_HPP_
+#ifndef HDT_ITERATOR_HPP_
+#define HDT_ITERATOR_HPP_
 
 #include "SingleTriple.hpp"
 
@@ -169,4 +169,4 @@ public:
 
 }
 
-#endif /* ITERATOR_HPP_ */
+#endif /* HDT_ITERATOR_HPP_ */

--- a/hdt-lib/include/Iterator.hpp
+++ b/hdt-lib/include/Iterator.hpp
@@ -101,9 +101,6 @@ public:
     }
 };
 
-
-
-
 class IteratorTripleID {
 public:
     virtual ~IteratorTripleID() { }

--- a/hdt-lib/include/Iterator.hpp
+++ b/hdt-lib/include/Iterator.hpp
@@ -32,11 +32,11 @@
 #ifndef ITERATOR_HPP_
 #define ITERATOR_HPP_
 
+#include "SingleTriple.hpp"
+
 #include <vector>
 #include <string>
 #include <fstream>
-
-#include <SingleTriple.hpp>
 
 namespace hdt {
 

--- a/hdt-lib/include/RDF.hpp
+++ b/hdt-lib/include/RDF.hpp
@@ -29,7 +29,6 @@
  *
  */
 
-
 #ifndef RDF_HPP_
 #define RDF_HPP_
 
@@ -60,9 +59,7 @@ public:
  * Provides writable access to a RDF repository, search triples, insert, remove.
  */
 class RDFStorage : public RDFAccess {
-
 public:
-
 	virtual ~RDFStorage() { }
 
 	/**

--- a/hdt-lib/include/RDF.hpp
+++ b/hdt-lib/include/RDF.hpp
@@ -33,8 +33,8 @@
 #ifndef RDF_HPP_
 #define RDF_HPP_
 
-#include <SingleTriple.hpp>
-#include <Iterator.hpp>
+#include "SingleTriple.hpp"
+#include "Iterator.hpp"
 
 namespace hdt {
 

--- a/hdt-lib/include/RDF.hpp
+++ b/hdt-lib/include/RDF.hpp
@@ -29,8 +29,8 @@
  *
  */
 
-#ifndef RDF_HPP_
-#define RDF_HPP_
+#ifndef HDT_RDF_HPP_
+#define HDT_RDF_HPP_
 
 #include "SingleTriple.hpp"
 #include "Iterator.hpp"
@@ -89,4 +89,4 @@ public:
 
 }
 
-#endif /* RDF_HPP_ */
+#endif /* HDT_RDF_HPP_ */

--- a/hdt-lib/include/RDFParser.hpp
+++ b/hdt-lib/include/RDFParser.hpp
@@ -33,14 +33,13 @@
 #ifndef RDFPARSER_H_
 #define RDFPARSER_H_
 
+#include "SingleTriple.hpp"
+#include "Iterator.hpp"
+#include "HDTEnums.hpp"
+
 #include <string>
 #include <istream>
 #include <stdint.h>
-
-#include <SingleTriple.hpp>
-#include <Iterator.hpp>
-#include <HDTEnums.hpp>
-
 
 namespace hdt {
 

--- a/hdt-lib/include/RDFParser.hpp
+++ b/hdt-lib/include/RDFParser.hpp
@@ -29,7 +29,6 @@
  *
  */
 
-
 #ifndef RDFPARSER_H_
 #define RDFPARSER_H_
 

--- a/hdt-lib/include/RDFParser.hpp
+++ b/hdt-lib/include/RDFParser.hpp
@@ -29,8 +29,8 @@
  *
  */
 
-#ifndef RDFPARSER_H_
-#define RDFPARSER_H_
+#ifndef HDT_RDFPARSER_HPP_
+#define HDT_RDFPARSER_HPP_
 
 #include "SingleTriple.hpp"
 #include "Iterator.hpp"
@@ -103,4 +103,4 @@ public:
 
 }
 
-#endif /* RDFPARSER_H_ */
+#endif /* HDT_RDFPARSER_HPP_ */

--- a/hdt-lib/include/RDFSerializer.hpp
+++ b/hdt-lib/include/RDFSerializer.hpp
@@ -32,11 +32,12 @@
 #ifndef RDFSERIALIZER_H_
 #define RDFSERIALIZER_H_
 
+#include "SingleTriple.hpp"
+#include "Iterator.hpp"
+#include "HDTEnums.hpp"
+#include "HDTListener.hpp"
+
 #include <iostream>
-#include <SingleTriple.hpp>
-#include <Iterator.hpp>
-#include <HDTEnums.hpp>
-#include <HDTListener.hpp>
 
 namespace hdt {
 

--- a/hdt-lib/include/RDFSerializer.hpp
+++ b/hdt-lib/include/RDFSerializer.hpp
@@ -29,8 +29,8 @@
  *
  */
 
-#ifndef RDFSERIALIZER_H_
-#define RDFSERIALIZER_H_
+#ifndef HDT_RDFSERIALIZER_HPP_
+#define HDT_RDFSERIALIZER_HPP_
 
 #include "SingleTriple.hpp"
 #include "Iterator.hpp"
@@ -56,4 +56,4 @@ public:
 
 }
 
-#endif /* RDFSERIALIZER_H_ */
+#endif /* HDT_RDFSERIALIZER_HPP_ */

--- a/hdt-lib/include/SingleTriple.hpp
+++ b/hdt-lib/include/SingleTriple.hpp
@@ -32,11 +32,11 @@
 #ifndef SINGLETRIPLE_HPP_
 #define SINGLETRIPLE_HPP_
 
+#include "HDTEnums.hpp"
+
 #include <iostream>
 #include <string>
 #include <vector>
-
-#include <HDTEnums.hpp>
 
 using namespace std;
 

--- a/hdt-lib/include/SingleTriple.hpp
+++ b/hdt-lib/include/SingleTriple.hpp
@@ -29,8 +29,8 @@
  *
  */
 
-#ifndef SINGLETRIPLE_HPP_
-#define SINGLETRIPLE_HPP_
+#ifndef HDT_SINGLETRIPLE_HPP_
+#define HDT_SINGLETRIPLE_HPP_
 
 #include "HDTEnums.hpp"
 
@@ -533,4 +533,4 @@ public:
 
 }
 
-#endif /* SINGLETRIPLE_HPP_ */
+#endif /* HDT_SINGLETRIPLE_HPP_ */

--- a/hdt-lib/include/SingleTriple.hpp
+++ b/hdt-lib/include/SingleTriple.hpp
@@ -42,7 +42,6 @@ using namespace std;
 
 namespace hdt {
 
-
 #define IS_VARIABLE(a) ( (a).size()>0 && (a).at(0)=='?')
 #define IS_URI(a) ( (a).size()>0 && (a).at(0)!='<' && (a).at(0)!='_')
 #define IS_LITERAL(a) ( (a).size()>0 && (a).at(0)=='"')
@@ -225,7 +224,7 @@ public:
 		unsigned int predicate = pattern.getPredicate();
                 unsigned int object = pattern.getObject();
 
-		if (subject == 0 || subject == this->subject) {                    
+		if (subject == 0 || subject == this->subject) {
                     if (predicate == 0 || predicate == this->predicate) {
                         if (object == 0 || object == this->object) {
                             return true;

--- a/hdt-lib/include/Triples.hpp
+++ b/hdt-lib/include/Triples.hpp
@@ -29,8 +29,8 @@
  *
  */
 
-#ifndef HDT_TRIPLES_
-#define HDT_TRIPLES_
+#ifndef HDT_TRIPLES_HPP_
+#define HDT_TRIPLES_HPP_
 
 #include "HDTEnums.hpp"
 #include "SingleTriple.hpp"
@@ -203,4 +203,4 @@ public:
 
 }
 
-#endif /* HDT_TRIPLES_ */
+#endif /* HDT_TRIPLES_HPP_ */

--- a/hdt-lib/include/Triples.hpp
+++ b/hdt-lib/include/Triples.hpp
@@ -32,11 +32,11 @@
 #ifndef HDT_TRIPLES_
 #define HDT_TRIPLES_
 
-#include <HDTEnums.hpp>
-#include <SingleTriple.hpp>
-#include <Header.hpp>
-#include <ControlInformation.hpp>
-#include <HDTListener.hpp>
+#include "HDTEnums.hpp"
+#include "SingleTriple.hpp"
+#include "Header.hpp"
+#include "ControlInformation.hpp"
+#include "HDTListener.hpp"
 
 #include <iostream>
 #include <iterator>

--- a/hdt-lib/include/Triples.hpp
+++ b/hdt-lib/include/Triples.hpp
@@ -204,4 +204,3 @@ public:
 }
 
 #endif /* HDT_TRIPLES_ */
-


### PR DESCRIPTION
Right now, including e.g. the `HDTManager.hpp` header file, as per the example programs, requires that in fact all the library's header files be located in the compiler's include path, since `HDTManager.hpp` refers to them with the `<header.hpp>` syntax instead of the correct `"header.hpp"`. This pull request fixes that, enabling the headers to e.g. be installed as and used from `/usr/local/include/hdt/*.hpp`.

Also, the header file inclusion guards were using inconsistent naming and in many cases (e.g., `ITERATOR_HPP_`) inadvertently stepping over the user's macro namespace. This pull request fixes that as well, by prefixing all guards with `HDT_` and normalizing their structure.
