### PR TITLE
Fix most compiler warnings

### DIFF
--- a/hdt-lib/Makefile
+++ b/hdt-lib/Makefile
@@ -9,7 +9,13 @@ LIBZ_SUPPORT=true
 SERD_SUPPORT=true
 
 CPP=g++
-FLAGS=-O3 -Wno-deprecated
+
+ifeq ($(CPP), g++)
+FLAGS=-O3 -Wno-deprecated -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-unused-but-set-variable
+else
+FLAGS=-O3 -Wno-deprecated -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare
+endif
+
 INCLUDES=-I $(LIBCDSPATH)/includes/ -I /usr/local/include -I ./include -I /opt/local/include -I /usr/include
 LDFLAGS=
 DOXYGEN=doxygen

--- a/hdt-lib/include/Iterator.hpp
+++ b/hdt-lib/include/Iterator.hpp
@@ -59,7 +59,7 @@ public:
 		return 0;
 	}
 
-	virtual void freeStr(unsigned char *ptr) {
+	virtual void freeStr(unsigned char* /*ptr*/) {
 
 	}
 };
@@ -131,16 +131,16 @@ public:
 	virtual bool canGoTo() {
 		return false;
 	}
-	virtual void goTo(unsigned int pos) {
+	virtual void goTo(unsigned int /*pos*/) {
 	}
-	virtual bool findNextOccurrence(unsigned int value, unsigned char component) {
+	virtual bool findNextOccurrence(unsigned int /*value*/, unsigned char /*component*/) {
 		return false;
 	}
 	virtual TripleComponentOrder getOrder() {
 		return Unknown;
 	}
 
-    virtual bool isSorted(TripleComponentRole role) {
+    virtual bool isSorted(TripleComponentRole /*role*/) {
 	return false;
     }
 };

--- a/hdt-lib/include/SingleTriple.hpp
+++ b/hdt-lib/include/SingleTriple.hpp
@@ -517,10 +517,10 @@ public:
 	unsigned int getNumVars() {
 	    return 0;
 	}
-	string getVar(unsigned int numvar) {
+	string getVar(unsigned int /*numvar*/) {
 	    throw "No such variable";
 	}
-	const char *getVarName(unsigned int numvar) {
+	const char *getVarName(unsigned int /*numvar*/) {
 	    throw "No such variable";
 	}
 	unsigned int estimatedNumResults() {

--- a/hdt-lib/include/Triples.hpp
+++ b/hdt-lib/include/Triples.hpp
@@ -125,7 +125,7 @@ public:
 
     virtual bool isIndexed()=0;
 
-    virtual size_t getNumAppearances(size_t pred) {
+    virtual size_t getNumAppearances(size_t /*pred*/) {
         return 0;
     }
 

--- a/hdt-lib/src/bitsequence/BitSequence375.cpp
+++ b/hdt-lib/src/bitsequence/BitSequence375.cpp
@@ -36,20 +36,20 @@ namespace hdt
 {
 
 
-BitSequence375::BitSequence375(): numbits(0), numones(0), numwords(0), indexReady(false), isMapped(false)
+BitSequence375::BitSequence375(): numbits(0), numwords(0), numones(0), isMapped(false), indexReady(false)
 {
     data.resize(1); //Ensure valid pointer.
     array = &data[0];
 }
 
-BitSequence375::BitSequence375(size_t capacity): numbits(0), numones(0), indexReady(false), isMapped(false)
+BitSequence375::BitSequence375(size_t capacity): numbits(0), numones(0), isMapped(false), indexReady(false)
 {
     numwords = numWords(numbits);
     data.resize(numwords);
     array = &data[0];
 }
 
-BitSequence375::BitSequence375(size_t *bitarray, size_t n) : numbits(n), indexReady(false), isMapped(false)
+BitSequence375::BitSequence375(size_t *bitarray, size_t n) : numbits(n), isMapped(false), indexReady(false)
 {
     numwords = numWords(numbits);
     data.resize(numwords);

--- a/hdt-lib/src/dictionary/FourSectionDictionary.cpp
+++ b/hdt-lib/src/dictionary/FourSectionDictionary.cpp
@@ -133,6 +133,7 @@ unsigned int FourSectionDictionary::stringToId(std::string &key, TripleComponent
 		}
         return 0;
 	}
+	return 0;
 }
 
 

--- a/hdt-lib/src/dictionary/LiteralDictionary.cpp
+++ b/hdt-lib/src/dictionary/LiteralDictionary.cpp
@@ -148,6 +148,7 @@ unsigned int LiteralDictionary::stringToId(std::string &key, TripleComponentRole
       return 0;
 		}
 	}
+	return 0;
 }
 
 void LiteralDictionary::load(std::istream & input, ControlInformation & ci,	ProgressListener *listener) {

--- a/hdt-lib/src/dictionary/PlainDictionary.cpp
+++ b/hdt-lib/src/dictionary/PlainDictionary.cpp
@@ -120,6 +120,7 @@ unsigned int PlainDictionary::stringToId(std::string &key, TripleComponentRole p
 		ret = hashObject.find(key.c_str());
     return ret==hashObject.end()    ? 0 : ret->second->id;
 	}
+	return 0;
 }
 
 void PlainDictionary::startProcessing(ProgressListener *listener)

--- a/hdt-lib/src/libdcs/CSD_FMIndex.cpp
+++ b/hdt-lib/src/libdcs/CSD_FMIndex.cpp
@@ -59,12 +59,12 @@ CSD_FMIndex::CSD_FMIndex(hdt::IteratorUCharString *it, bool sparse_bitsequence, 
 	size_t len = 0;
 	size_t reservedSize = 1024;
 	text = (unsigned char*) malloc(reservedSize * sizeof(unsigned char));
-	std:vector < size_t > samplingsPositions;
+	std::vector < size_t > samplingsPositions;
 
 	text[0] = '\1'; //We suppose that \1 is not part of the text
 	maxlength = 0;
 	numstrings = 0;
-	uint m_l = 0;
+	//uint m_l = 0;
 
 	size_t total = 1;
 
@@ -292,7 +292,7 @@ size_t CSD_FMIndex::load(unsigned char *ptr, unsigned char *ptrMax)
     std::stringstream localStream;
     localStream.rdbuf()->pubsetbuf((char*)ptr, ptrMax-ptr);
 
-    unsigned char type = localStream.get(); // Load expects the type already read.
+    //unsigned char type = localStream.get(); // Load expects the type already read.
 
     this->type = FMINDEX;
     this->numstrings = loadValue<uint32_t>(localStream);
@@ -365,7 +365,7 @@ void csd::CSD_FMIndex::fillSuggestions(const char *base,
         vector<std::string> &out, int maxResults) {
     size_t len = strlen(base);
     unsigned char *n_s = new unsigned char[len + 1];
-    uint o;
+    //uint o;
     n_s[0] = '\1';
     for (uint32_t i = 1; i <= len; i++)
         n_s[i] = base[i - 1];

--- a/hdt-lib/src/libdcs/CSD_HTFC.cpp
+++ b/hdt-lib/src/libdcs/CSD_HTFC.cpp
@@ -535,7 +535,7 @@ bool CSD_HTFC::locateBlock(const unsigned char *s, uint *block)
 	if (encoffset > 0) encpos++;
 
 	long long int l = 0, r = nblocks-1, c;
-	uint delta, cmplen;
+	uint delta, cmplen; // FIXME: cmplen is assigned, below, but never actually used?
 	int cmp;
 
 	while (l <= r)

--- a/hdt-lib/src/libdcs/CSD_HTFC.cpp
+++ b/hdt-lib/src/libdcs/CSD_HTFC.cpp
@@ -58,7 +58,7 @@ CSD_HTFC::CSD_HTFC(hdt::IteratorUCharString *it, uint32_t blocksize, hdt::Progre
 
 	vector<uint> xblocks; // Temporal storage for start positions
 
-	unsigned char *previousStr, *currentStr = NULL;
+	unsigned char *previousStr = NULL, *currentStr = NULL;
 	uint previousLength = 0, currentLength = 0;
 
 	while (it->hasNext())

--- a/hdt-lib/src/libdcs/CSD_HTFC.cpp
+++ b/hdt-lib/src/libdcs/CSD_HTFC.cpp
@@ -151,7 +151,7 @@ CSD_HTFC::CSD_HTFC(hdt::IteratorUCharString *it, uint32_t blocksize, hdt::Progre
 
 	// Auxiliar variables for Hu-Tucker encoding
 	uint offset = 0, cblocks = 0;
-	uint64_t i = 0, slength=0;
+	uint64_t i = 0/*, slength=0*/;
 
 	while (i < bytesfc)
 	{

--- a/hdt-lib/src/libdcs/CSD_PFC.cpp
+++ b/hdt-lib/src/libdcs/CSD_PFC.cpp
@@ -140,7 +140,7 @@ uint32_t CSD_PFC::locate(const unsigned char *s, uint32_t len)
 		return 0;
 
 	// Locating the candidate block for 's'
-    size_t block;
+    size_t block = 0;
 	bool cmp = locateBlock(s, &block);
 
 	//	dumpBlock(block);
@@ -485,7 +485,7 @@ hdt::IteratorUCharString *CSD_PFC::listAll() {
 
 void CSD_PFC::fillSuggestions(const char *base, vector<std::string> &out, int maxResults)
 {
-    size_t block;
+    size_t block = 0;
 	locateBlock((unsigned char *)base, &block);
 
 	if(!text || !blocks || block>=nblocks){

--- a/hdt-lib/src/sequence/HuffmanSequence.cpp
+++ b/hdt-lib/src/sequence/HuffmanSequence.cpp
@@ -120,9 +120,9 @@ void HuffmanSequence::save(std::ostream & output)
 	// Calculate size
 	unsigned int numElements = vectorPlain.size();
 	unsigned int encodedEntries = 1+pos/(sizeof(unsigned int)*8);
-	unsigned int bytes = 1+pos/8;
 
 #if 0
+	unsigned int bytes = 1+pos/8;
 	cout << "Total bits: " << pos << endl;
 	cout << "Total entries: " << encodedEntries << endl;
 	cout << "Total bytes: " << bytes << endl;

--- a/hdt-lib/src/sequence/LogSequence.cpp
+++ b/hdt-lib/src/sequence/LogSequence.cpp
@@ -91,7 +91,7 @@ void LogSequence::load(std::istream & input)
     array = new cds_utils::Array(input);
 }
 
-size_t LogSequence::load(unsigned char *ptr, unsigned char *ptrMax, ProgressListener *listener)
+size_t LogSequence::load(const unsigned char *ptr, const unsigned char *ptrMax, ProgressListener *listener)
 {
 	 std::stringstream localStream;
 	 localStream.rdbuf()->pubsetbuf((char*)ptr, ptrMax-ptr);

--- a/hdt-lib/src/sequence/LogSequence.hpp
+++ b/hdt-lib/src/sequence/LogSequence.hpp
@@ -93,7 +93,7 @@ public:
     /**
      * Load a stream from a pointer. To be used with MMAP.
      */
-    size_t load(unsigned char *ptr, unsigned char *ptrMax, ProgressListener *listener=NULL);
+    size_t load(const unsigned char *ptr, const unsigned char *ptrMax, ProgressListener *listener=NULL);
 
 
 	std::string getType();

--- a/hdt-lib/src/sequence/LogSequence2.cpp
+++ b/hdt-lib/src/sequence/LogSequence2.cpp
@@ -41,7 +41,7 @@ using namespace std;
 
 namespace hdt {
 
-LogSequence2::LogSequence2() : numentries(0), numbits(32), IsMapped(false) {
+LogSequence2::LogSequence2() : numbits(32), numentries(0), IsMapped(false) {
 	maxval = maxVal(numbits);
 
     data.resize(1);
@@ -49,7 +49,7 @@ LogSequence2::LogSequence2() : numentries(0), numbits(32), IsMapped(false) {
     arraysize = 0;
 }
 
-LogSequence2::LogSequence2(unsigned int numbits) : numentries(0), numbits(numbits),  IsMapped(false) {
+LogSequence2::LogSequence2(unsigned int numbits) : numbits(numbits), numentries(0), IsMapped(false) {
 	maxval = maxVal(numbits);
 
     data.resize(1);
@@ -57,7 +57,7 @@ LogSequence2::LogSequence2(unsigned int numbits) : numentries(0), numbits(numbit
     arraysize = 0;
 }
 
-LogSequence2::LogSequence2(unsigned int numbits, size_t capacity) : numentries(0), numbits(numbits), IsMapped(false) {
+LogSequence2::LogSequence2(unsigned int numbits, size_t capacity) : numbits(numbits), numentries(0), IsMapped(false) {
 	maxval = maxVal(numbits);
 	size_t totalSize = numElementsFor(numbits, capacity);
     if(totalSize==0) data.reserve(1);

--- a/hdt-lib/src/sparql/CachedBinding.hpp
+++ b/hdt-lib/src/sparql/CachedBinding.hpp
@@ -23,7 +23,7 @@ private:
 	unsigned int readPos;
 
 public:
-	CachedBinding(VarBindingInterface *child) : child(child), readPos(0), numRows(0) {
+	CachedBinding(VarBindingInterface *child) : child(child), numRows(0), readPos(0) {
 
 		for(unsigned int i=0;i<child->getNumVars();i++) {
 			varnames.push_back(child->getVarName(i));

--- a/hdt-lib/src/sparql/CachedBinding.hpp
+++ b/hdt-lib/src/sparql/CachedBinding.hpp
@@ -15,15 +15,15 @@
 namespace hdt {
 class CachedBinding : public VarBindingInterface {
 private:
-	VarBindingInterface *child;
+	//VarBindingInterface *child;
 	vector<string> varnames;
 	vector<vector <unsigned int> > values;
 	vector<bool> varSorted;
-	unsigned int numRows;
+	//unsigned int numRows;
 	unsigned int readPos;
 
 public:
-	CachedBinding(VarBindingInterface *child) : child(child), numRows(0), readPos(0) {
+	CachedBinding(VarBindingInterface *child) : /*child(child), numRows(0),*/ readPos(0) {
 
 		for(unsigned int i=0;i<child->getNumVars();i++) {
 			varnames.push_back(child->getVarName(i));

--- a/hdt-lib/src/sparql/IndexJoinBinding.cpp
+++ b/hdt-lib/src/sparql/IndexJoinBinding.cpp
@@ -10,9 +10,9 @@
 namespace hdt {
 
 IndexJoinBinding::IndexJoinBinding(char *var, VarBindingInterface *left, VarBindingInterface *right) :
-	BaseJoinBinding(var, left, right),
-	leftCount(0),
-	rightCount(0)
+	BaseJoinBinding(var, left, right)
+	//leftCount(0),
+	//rightCount(0)
 {
     	cerr << "Index join of " << left->estimatedNumResults() << "x" << right->estimatedNumResults() << endl;
 	goToStart();

--- a/hdt-lib/src/sparql/IndexJoinBinding.hpp
+++ b/hdt-lib/src/sparql/IndexJoinBinding.hpp
@@ -15,8 +15,8 @@ namespace hdt {
 class IndexJoinBinding : public BaseJoinBinding {
 	unsigned int leftVarValue;
 	vector< vector<unsigned int> > leftOperands, rightOperands;
-	unsigned int leftCount, rightCount;
-	bool remainingRight;
+	//unsigned int leftCount, rightCount;
+	//bool remainingRight;
 public:
 	IndexJoinBinding(char *var, VarBindingInterface *left, VarBindingInterface *right);
 	virtual ~IndexJoinBinding();

--- a/hdt-lib/src/sparql/SortBinding.hpp
+++ b/hdt-lib/src/sparql/SortBinding.hpp
@@ -10,11 +10,11 @@ class SortBinding : public VarBindingInterface
 private:
     vector<string> varnames;
     unsigned int *table;
-    char *joinVar;
-    unsigned int joinVarPos;
+    //char *joinVar;
+    //unsigned int joinVarPos;
     unsigned int numRows;
     unsigned int numCols;
-    unsigned int currentRow;
+    //unsigned int currentRow;
 public:
     // Sort all of the child by var
     SortBinding(char *var, VarBindingInterface *child);

--- a/hdt-lib/src/triples/BitmapTriples.hpp
+++ b/hdt-lib/src/triples/BitmapTriples.hpp
@@ -241,7 +241,7 @@ private:
 	AdjacencyList adjY, adjZ, adjIndex;
 	unsigned int patX, patY, patZ;
     size_t posIndex;
-    size_t predicateOcurrence, numOcurrences;
+    //size_t predicateOcurrence, numOcurrences;
 	long long minIndex, maxIndex;
 	unsigned int x, y, z;
 

--- a/hdt-lib/src/triples/BitmapTriplesIterators.cpp
+++ b/hdt-lib/src/triples/BitmapTriplesIterators.cpp
@@ -807,7 +807,7 @@ void ObjectIndexIterator::calculateRange() {
                 // Binary Search to find left boundary
                 long left=minIndex;
                 long right=mid;
-                long int pos;
+                long int pos=0;
 
                 while(left<=right) {
                     pos = (left+right)/2;
@@ -894,7 +894,7 @@ void ObjectIndexIterator::goTo(unsigned int pos)
 bool ObjectIndexIterator::findNextOccurrence(unsigned int value, unsigned char component) {
     if(component==1) {
         if(patY!=0) {
-            unsigned int posZ, posY;
+            unsigned int posZ=0, posY=0;
             while(x!=value) {
                 posZ = getPosZ(posIndex);
                 posY = adjZ.findListIndex(posZ);

--- a/hdt-lib/src/triples/BitmapTriplesIterators.cpp
+++ b/hdt-lib/src/triples/BitmapTriplesIterators.cpp
@@ -943,8 +943,8 @@ bool ObjectIndexIterator::isSorted(TripleComponentRole role) {
 BTInterleavedIterator::BTInterleavedIterator(BitmapTriples *triples, size_t skip) :
             triples(triples),
             adjY(triples->arrayY, triples->bitmapY),
-            posZ(0),
             adjZ(triples->arrayZ, triples->bitmapZ),
+            posZ(0),
             skip(skip)
 {
 }

--- a/hdt-lib/src/triples/BitmapTriplesIterators.cpp
+++ b/hdt-lib/src/triples/BitmapTriplesIterators.cpp
@@ -320,8 +320,8 @@ MiddleWaveletIterator::MiddleWaveletIterator(BitmapTriples *trip, TripleID &pat)
     pattern(pat),
     adjY(trip->arrayY, trip->bitmapY),
     adjZ(trip->arrayZ, trip->bitmapZ),
-    predicateOcurrence(1),
-    predicateIndex(trip->predicateIndex)
+    predicateIndex(trip->predicateIndex),
+    predicateOcurrence(1)
 {
     // Convert pattern to local order.
     swapComponentOrder(&pattern, SPO, triples->order);
@@ -942,10 +942,10 @@ bool ObjectIndexIterator::isSorted(TripleComponentRole role) {
 
 BTInterleavedIterator::BTInterleavedIterator(BitmapTriples *triples, size_t skip) :
             triples(triples),
-            skip(skip),
-            posZ(0),
             adjY(triples->arrayY, triples->bitmapY),
-            adjZ(triples->arrayZ, triples->bitmapZ)
+            posZ(0),
+            adjZ(triples->arrayZ, triples->bitmapZ),
+            skip(skip)
 {
 }
 

--- a/hdt-lib/src/triples/CompactTriples.cpp
+++ b/hdt-lib/src/triples/CompactTriples.cpp
@@ -42,7 +42,7 @@ CompactTriples::CompactTriples() : numTriples(0), order(SPO) {
 	streamZ = IntSequence::getArray(spec.get("stream.z"));
 }
 
-CompactTriples::CompactTriples(HDTSpecification &specification) : numTriples(0), spec(specification) {
+CompactTriples::CompactTriples(HDTSpecification &specification) : spec(specification), numTriples(0) {
 	std::string orderStr = spec.get("triplesOrder");
 	order= parseOrder(orderStr.c_str());
 	if(order==Unknown)

--- a/hdt-lib/src/triples/CompactTriples.cpp
+++ b/hdt-lib/src/triples/CompactTriples.cpp
@@ -71,7 +71,7 @@ void CompactTriples::load(ModifiableTriples &triples, ProgressListener *listener
 	IteratorTripleID *it = triples.searchAll();
 
 	vector<unsigned int> vectorY, vectorZ;
-	unsigned int lastX, lastY, lastZ;
+	unsigned int lastX, lastY, lastZ; // FIXME: lastZ is assigned, below, but never actually used?
 	unsigned int x, y, z;
 
 	// First triple

--- a/hdt-lib/src/triples/CompactTriples.cpp
+++ b/hdt-lib/src/triples/CompactTriples.cpp
@@ -71,7 +71,7 @@ void CompactTriples::load(ModifiableTriples &triples, ProgressListener *listener
 	IteratorTripleID *it = triples.searchAll();
 
 	vector<unsigned int> vectorY, vectorZ;
-	unsigned int lastX, lastY, lastZ; // FIXME: lastZ is assigned, below, but never actually used?
+	unsigned int lastX=0, lastY=0, lastZ=0; // FIXME: lastZ is assigned, below, but never actually used?
 	unsigned int x, y, z;
 
 	// First triple

--- a/hdt-lib/src/triples/PlainTriples.cpp
+++ b/hdt-lib/src/triples/PlainTriples.cpp
@@ -211,7 +211,7 @@ TripleComponentOrder PlainTriples::getOrder()
 }
 
 PlainTriplesIterator::PlainTriplesIterator(PlainTriples *triples, TripleID & pattern, TripleComponentOrder order) :
-		pattern(pattern), order(order), triples(triples), pos(0)
+		pattern(pattern),/* order(order),*/ triples(triples), pos(0)
 {
 }
 

--- a/hdt-lib/src/triples/PlainTriples.cpp
+++ b/hdt-lib/src/triples/PlainTriples.cpp
@@ -143,7 +143,7 @@ void PlainTriples::load(std::istream &input, ControlInformation &controlInformat
 		throw "Trying to read PlainTriples but the data is not PlainTriples";
 	}
 
-	unsigned int numTriples = controlInformation.getUint("numTriples");
+	//unsigned int numTriples = controlInformation.getUint("numTriples");
 	order = (TripleComponentOrder) controlInformation.getUint("order");
 
 	IntermediateListener iListener(listener);

--- a/hdt-lib/src/triples/PlainTriples.cpp
+++ b/hdt-lib/src/triples/PlainTriples.cpp
@@ -269,6 +269,7 @@ unsigned int ComponentIterator::next()
 	case OBJECT:
 		return triple->getObject();
 	}
+	return 0;
 }
 
 bool ComponentIterator::hasNext()

--- a/hdt-lib/src/triples/PlainTriples.hpp
+++ b/hdt-lib/src/triples/PlainTriples.hpp
@@ -125,7 +125,7 @@ public:
 class PlainTriplesIterator : public IteratorTripleID {
 private:
 	TripleID pattern, returnTriple;
-	TripleComponentOrder order;
+	//TripleComponentOrder order;
 	PlainTriples *triples;
 	uint64_t pos;
 

--- a/hdt-lib/src/triples/TripleListDisk.cpp
+++ b/hdt-lib/src/triples/TripleListDisk.cpp
@@ -52,9 +52,9 @@ namespace hdt {
 
 TripleListDisk::TripleListDisk() :
 		capacity(0),
+		arrayTriples(NULL),
 		numValidTriples(0),
-		numTotalTriples(0),
-		arrayTriples(NULL)
+		numTotalTriples(0)
 {
 	std::string s("triplelistdiskXXXXXX");
 	std::vector<char> v(100);

--- a/hdt-lib/src/triples/TriplesList.cpp
+++ b/hdt-lib/src/triples/TriplesList.cpp
@@ -41,11 +41,11 @@
 
 namespace hdt {
 
-TriplesList::TriplesList() : order(Unknown), numValidTriples(0), ptr(NULL)
+TriplesList::TriplesList() : ptr(NULL), order(Unknown), numValidTriples(0)
 {
 }
 
-TriplesList::TriplesList(HDTSpecification &specification) : spec(specification), order(Unknown), ptr(NULL), numValidTriples(0) {
+TriplesList::TriplesList(HDTSpecification &specification) : spec(specification), ptr(NULL), order(Unknown), numValidTriples(0) {
 }
 
 TriplesList::~TriplesList()

--- a/hdt-lib/src/triples/TriplesList.cpp
+++ b/hdt-lib/src/triples/TriplesList.cpp
@@ -137,7 +137,7 @@ size_t TriplesList::load(unsigned char *ptr, unsigned char *ptrMax, ProgressList
     }
 
     order = (TripleComponentOrder) controlInformation.getUint("order");
-    unsigned long long totalTriples = controlInformation.getUint("numTriples");
+    //unsigned long long totalTriples = controlInformation.getUint("numTriples");
     this->numValidTriples = 100000000;
 
     //CHECKPTR(&ptr[count],ptrMax,numValidTriples*12);

--- a/hdt-lib/src/triples/predicateindex.hpp
+++ b/hdt-lib/src/triples/predicateindex.hpp
@@ -89,7 +89,7 @@ class PredicateIndexArray : public PredicateIndex {
     //LogSequence2 *predCount;
     BitSequence375 *bitmap;
     size_t currpred,currpos;
-    size_t numPredicates;
+    //size_t numPredicates;
     BitmapTriples *bitmapTriples;
 
 public:

--- a/hdt-lib/src/util/Histogram.h
+++ b/hdt-lib/src/util/Histogram.h
@@ -168,7 +168,7 @@ public:
 	 * Get the sum of all counts in the histogram.
 	 * @return The expected result.
 	 */
-        const unsigned int getTotalCount() const {
+        unsigned int getTotalCount() const {
 		unsigned int c(0U);
 		for (unsigned int i(0); i < nBins; ++i)
 			c += freq[i];

--- a/hdt-lib/src/util/fileUtil.cpp
+++ b/hdt-lib/src/util/fileUtil.cpp
@@ -157,7 +157,7 @@ void fileUtil::decompress(const char *input, const char * output, hdt::ProgressL
 #endif
 }
 
-DecompressStream::DecompressStream(const char *fileName) : filePipe(NULL), fileStream(NULL), in(NULL) {
+DecompressStream::DecompressStream(const char *fileName) : in(NULL), filePipe(NULL), fileStream(NULL) {
 
 #ifdef HAVE_LIBZ
 	gzStream = NULL;

--- a/hdt-lib/tests/jointest.cpp
+++ b/hdt-lib/tests/jointest.cpp
@@ -32,7 +32,7 @@ const string minusone="-1";
 const string zero="0";
 
 SparqlQuery parseJavi(string line) {
-	struct SparqlQuery output;
+	SparqlQuery output;
 	vector<string> pattern;
 
 	std::stringstream ss(line);
@@ -69,7 +69,7 @@ SparqlQuery parseJavi(string line) {
 #endif
 
 SparqlQuery parseSparql(string query) {
-        struct SparqlQuery output;
+        SparqlQuery output;
         string word;
         unsigned int phase = 0;
         vector<string> pattern;

--- a/hdt-lib/tools/hdtInfo.cpp
+++ b/hdt-lib/tools/hdtInfo.cpp
@@ -82,9 +82,9 @@ int main(int argc, char **argv) {
 
 	try {
 #ifdef HAVE_LIBZ
-		igzstream *inGz;
+		igzstream *inGz=NULL;
 #endif
-		ifstream *inF;
+		ifstream *inF=NULL;
 		istream *in=NULL;
 
 		string inputFile = argv[optind];

--- a/hdt-lib/tools/rdf2hdt.cpp
+++ b/hdt-lib/tools/rdf2hdt.cpp
@@ -57,7 +57,7 @@ void help() {
 int main(int argc, char **argv) {
 	string inputFile;
 	string outputFile;
-	bool verbose=false;
+	bool verbose=false; // NOTE: generates -Wunused-but-set-variable warning.
 	bool generateIndex=false;
 	string configFile;
 	string options;


### PR DESCRIPTION
This pull request improves code quality by fixing most `-Wall` and `-Wextra` compiler warnings in the _hdt-lib_ code base. The warnings were found and confirmed resolved using both the GCC and Clang compilers.

This is strictly an improvement over the previous situation and reins in some potentially undefined behavior. Where control paths exist that led to use of uninitialized variables, which could have contained any random integer value, they will now have a zero value. Where control paths exist that could have potentially resulted in undefined values being returned, they will now return zero.

(As noted in 83c2f232f130a579bc2660cb2e3f42f135ffab07, a follow-up task would be to more closely examine the logic of such control paths, as their logic is quite possibly deficient in edge cases where such variables would have actually been used uninitialized.)

At the strictest `-Wall -Wextra` static analysis level, there remain the following warnings with GCC 4.8:

* `-Wunused-parameter` (unused parameter): 523x. These can safely be ignored.

* `-Wsign-compare` (comparison between signed and unsigned integer expressions): 24x. These should still all be examined in the future, as they may hide integer underflow/overflow bugs.

* `-Wunused-but-set-variable` (variable set but not used): 3x. In 31cab82b9044473b3fb03d41ce7f03f8bbf8a377, I've annotated two of these with FIXME comments for later examination, and the third one is harmless.

Accordingly, the _hdt-lib_ project now builds without any compiler warnings (in either GCC 4.8 or Clang 3.6) with `CPPFLAGS` set to `-Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-unused-but-set-variable`. I've amended the `Makefile` accordingly.

For the record, I've attached the logs of building the _hdt-lib_ project with `-Wall -Wextra` from _before_ the improvements that constitute this pull request, such that the improvement is clearly observable:

* [compiler-warnings-gcc.txt](https://github.com/rdfhdt/hdt-cpp/files/37962/compiler-warnings-gcc.txt)
* [compiler-warnings-clang.txt](https://github.com/rdfhdt/hdt-cpp/files/37963/compiler-warnings-clang.txt)

