### PR TITLE
FIXED: Emit header http://purl.org/dc/terms/issued in valid XSD time.

### DIFF
--- a/hdt-lib/src/hdt/BasicHDT.cpp
+++ b/hdt-lib/src/hdt/BasicHDT.cpp
@@ -366,6 +366,9 @@ void BasicHDT::fillHeader(string& baseUri) {
 	time(&now);
 	struct tm* today = localtime(&now);
 	strftime(date, 40, "%Y-%m-%dT%H:%M:%S%z", today);
+	char *tzm = date+strlen(date) - 2;
+	memmove(tzm+1, tzm, 3);
+	*tzm = ':';
 	header->insert(publicationInfoNode, HDTVocabulary::DUBLIN_CORE_ISSUED, date);
 }
 


### PR DESCRIPTION
fillHeader() used HHMM for the timezone, but XSD requires HH:MM according to https://www.w3.org/TR/xmlschema11-2/#nt-tzFrag
