### PR TITLE
Add method to directly load triples into BasicHDT

### DIFF
--- a/hdt-lib/src/hdt/BasicHDT.cpp
+++ b/hdt-lib/src/hdt/BasicHDT.cpp
@@ -438,7 +438,7 @@ void BasicHDT::loadFromRDF(const char *fileName, string baseUri, RDFNotation not
 	}
 }
 
-void BasicHDT::loadFromTriples(IteratorTripleString* triples, string baseUri) {
+void BasicHDT::loadFromTriples(IteratorTripleString* triples, string baseUri, ProgressListener *listener) {
 	try {
 		// Make sure that URI starts and ends with <>
 		if(baseUri.at(0)!='<')
@@ -446,8 +446,13 @@ void BasicHDT::loadFromTriples(IteratorTripleString* triples, string baseUri) {
 		if(baseUri.at(baseUri.length()-1)!='>')
 			baseUri.append(">");
 
-		loadDictionary(triples);
-		loadTriples(triples);
+		IntermediateListener iListener(listener);
+
+		iListener.setRange(0,50);
+		loadDictionary(triples, &iListener);
+
+		iListener.setRange(50,99);
+		loadTriples(triples, &iListener);
 
 		fillHeader(baseUri);
 

--- a/hdt-lib/src/hdt/BasicHDT.hpp
+++ b/hdt-lib/src/hdt/BasicHDT.hpp
@@ -28,6 +28,7 @@
 #ifndef BASICHDT_HPP_
 #define BASICHDT_HPP_
 
+#include <functional>
 #include <HDTSpecification.hpp>
 #include <HDT.hpp>
 

--- a/hdt-lib/src/hdt/BasicHDT.hpp
+++ b/hdt-lib/src/hdt/BasicHDT.hpp
@@ -54,6 +54,8 @@ private:
 
 	void loadDictionary(const char *fileName, const char *baseUri, RDFNotation notation, ProgressListener *listener);
 	void loadTriples(const char *fileName, const char *baseUri, RDFNotation notation, ProgressListener *listener);
+	void loadDictionary(IteratorTripleString* triples);
+	void loadTriples(IteratorTripleString* triples);
 
 	void addDictionaryFromHDT(const char *fileName, ModifiableDictionary *dict, ProgressListener *listener=NULL);
 	void loadDictionaryFromHDTs(const char** fileName, size_t numFiles, const char* baseUri, ProgressListener* listener=NULL);
@@ -87,6 +89,8 @@ public:
 	Triples *getTriples();
 
 	void loadFromRDF(const char *fileName, string baseUri, RDFNotation notation, ProgressListener *listener = NULL);
+
+	void loadFromTriples(IteratorTripleString* triples, string baseUri);
 
 	/**
 	 * @param input

--- a/hdt-lib/src/hdt/BasicHDT.hpp
+++ b/hdt-lib/src/hdt/BasicHDT.hpp
@@ -35,7 +35,6 @@
 
 namespace hdt {
 
-
 class BasicHDT : public HDT {
 private:
 	Header *header;
@@ -52,10 +51,12 @@ private:
 	ModifiableDictionary *getLoadDictionary();
 	ModifiableTriples *getLoadTriples();
 
+	void loadDictionary(std::function<void(RDFCallback&)> tripleLoader, ProgressListener *listener);
 	void loadDictionary(const char *fileName, const char *baseUri, RDFNotation notation, ProgressListener *listener);
+	void loadDictionary(IteratorTripleString* triples, ProgressListener *listener=NULL);
+	void loadTriples(std::function<void(RDFCallback&)> tripleLoader, ProgressListener *listener);
 	void loadTriples(const char *fileName, const char *baseUri, RDFNotation notation, ProgressListener *listener);
-	void loadDictionary(IteratorTripleString* triples);
-	void loadTriples(IteratorTripleString* triples);
+	void loadTriples(IteratorTripleString* triples, ProgressListener *listener=NULL);
 
 	void addDictionaryFromHDT(const char *fileName, ModifiableDictionary *dict, ProgressListener *listener=NULL);
 	void loadDictionaryFromHDTs(const char** fileName, size_t numFiles, const char* baseUri, ProgressListener* listener=NULL);

--- a/hdt-lib/src/hdt/BasicHDT.hpp
+++ b/hdt-lib/src/hdt/BasicHDT.hpp
@@ -91,7 +91,7 @@ public:
 
 	void loadFromRDF(const char *fileName, string baseUri, RDFNotation notation, ProgressListener *listener = NULL);
 
-	void loadFromTriples(IteratorTripleString* triples, string baseUri);
+	void loadFromTriples(IteratorTripleString* triples, string baseUri, ProgressListener *listener = NULL);
 
 	/**
 	 * @param input


### PR DESCRIPTION
This allows triples to be directly loaded into a BasicHDT without having to read them from a file.
