### PR TITLE
Implement goToStart in RDF parsers

### DIFF
--- a/hdt-lib/include/RDFParser.hpp
+++ b/hdt-lib/include/RDFParser.hpp
@@ -72,6 +72,7 @@ public:
 	virtual void reset()=0;
 	virtual uint64_t getPos()=0;
 	virtual uint64_t getSize()=0;
+	void goToStart();
 
 	static RDFParserPull *getParserPull(const char *filename, RDFNotation notation);
 	static RDFParserPull *getParserPull(std::istream &stream, RDFNotation notation);

--- a/hdt-lib/src/rdf/RDFParser.cpp
+++ b/hdt-lib/src/rdf/RDFParser.cpp
@@ -17,6 +17,10 @@
 
 namespace hdt {
 
+void RDFParserPull::goToStart() {
+    this->reset();
+}
+
 RDFParserPull *RDFParserPull::getParserPull(std::istream &stream, RDFNotation notation) {
 	if(notation==NTRIPLES) {
 		return new RDFParserNtriples(stream,notation);


### PR DESCRIPTION
In order to make HDT construction possible from iterators backed by an RDF parser, the `goToStart()` method needs to be implemented. This PR implements this for all RDF parsers.