### PR TITLE
Fix compilation error in KyotoDictionary.cpp

### DIFF
--- a/hdt-lib/src/dictionary/KyotoDictionary.cpp
+++ b/hdt-lib/src/dictionary/KyotoDictionary.cpp
@@ -47,7 +47,7 @@ KyotoDictionary::KyotoDictionary() {
 }
 
 KyotoDictionary::KyotoDictionary(HDTSpecification &specification) : spec(specification) {
-	string map = ""
+	string map = "";
 	try{
 		map = spec.get("dictionary.mapping");
 	}catch(exception& e){}


### PR DESCRIPTION
42caf474c467d667d17deaf2a300e6b77d7fa90a introduced a compilation error due to a missing semicolon.