### PR TITLE
Improved exception handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,6 @@ stamp-h1
 *.a
 **/examples/*
 **/tests/*
-**/tools/*
 libcds-v1.0.12/includes
 !**/examples/*.cpp
 !**/tests/*.cpp
-!**/tools/*.cpp

--- a/hdt-lib/include/Header.hpp
+++ b/hdt-lib/include/Header.hpp
@@ -81,7 +81,7 @@ public:
 			hdt::TripleString *ts = it->next();
 			out = ts->getObject();
 		} else {
-		    throw "Not found";
+		    throw std::runtime_error("Not found");
 		}
 		delete it;
 

--- a/hdt-lib/include/RDFParser.hpp
+++ b/hdt-lib/include/RDFParser.hpp
@@ -88,9 +88,22 @@ public:
         byte(byte),
         line(line),
         column(column),
-        reason(reason) {
-
-    }
+        reason(reason) {  }
+    ParseException(uint64_t line, uint32_t column, string reason) :
+        // byte(byte),
+        line(line),
+        column(column),
+        reason(reason) {  }
+    ParseException(uint64_t line, string reason) :
+        // byte(byte),
+        line(line),
+        // column(column),
+        reason(reason) {  }
+    ParseException(string reason) :
+        // byte(byte),
+        // line(line),
+        // column(column),
+        reason(reason) {  }
 
     /** Returns a C-style character string describing the general cause
      *  of the current error.  */

--- a/hdt-lib/include/SingleTriple.hpp
+++ b/hdt-lib/include/SingleTriple.hpp
@@ -220,7 +220,7 @@ public:
 	 * @return boolean
 	 */
 	inline bool match(TripleID &pattern) {
-		unsigned int subject = pattern.getSubject();		
+		unsigned int subject = pattern.getSubject();
 		unsigned int predicate = pattern.getPredicate();
                 unsigned int object = pattern.getObject();
 
@@ -518,10 +518,10 @@ public:
 	    return 0;
 	}
 	string getVar(unsigned int /*numvar*/) {
-	    throw "No such variable";
+	    throw std::runtime_error("No such variable");
 	}
 	const char *getVarName(unsigned int /*numvar*/) {
-	    throw "No such variable";
+	    throw std::runtime_error("No such variable");
 	}
 	unsigned int estimatedNumResults() {
 	    return 0;

--- a/hdt-lib/src/bitsequence/BitSequence375.cpp
+++ b/hdt-lib/src/bitsequence/BitSequence375.cpp
@@ -145,7 +145,7 @@ size_t BitSequence375::rank1(const size_t pos) const
 
 void BitSequence375::set(const size_t i, bool val) {
 	if(isMapped) {
-		throw "This data structure is readonly when mapped.";
+		throw std::runtime_error("This data structure is readonly when mapped.");
 	}
 
 	size_t requiredCapacity = 1+(i/WORDSIZE);
@@ -200,7 +200,7 @@ void BitSequence375::save(ostream & out) const
 }
 
 
-#define CHECKPTR(base, max, size) if(((base)+(size))>(max)) throw "Could not read completely the HDT from the file.";
+#define CHECKPTR(base, max, size) if(((base)+(size))>(max)) throw std::runtime_error("Could not read completely the HDT from the file.");
 
 size_t BitSequence375::load(const unsigned char *ptr, const unsigned char *maxPtr, ProgressListener *listener){
 	size_t count=0;
@@ -208,14 +208,14 @@ size_t BitSequence375::load(const unsigned char *ptr, const unsigned char *maxPt
     // Check type
 	CHECKPTR(&ptr[count], maxPtr, 1);
     if(ptr[count++]!=TYPE_BITMAP_PLAIN) {
-        throw "Trying to read a BitSequence375 but the type does not match";
+        throw std::runtime_error("Trying to read a BitSequence375 but the type does not match");
     }
 
     // Read numbits
     uint64_t totalBits;
 	count += csd::VByte::decode(&ptr[count], maxPtr, &totalBits);
 	if(sizeof(size_t)==4 && totalBits>0xFFFFFFFF) {
-		throw "This File is too big to be processed using 32Bit version. Please compile with 64bit support";
+		throw std::runtime_error("This File is too big to be processed using 32Bit version. Please compile with 64bit support");
 	}
 	this->numbits = (size_t) totalBits;
 
@@ -224,14 +224,14 @@ size_t BitSequence375::load(const unsigned char *ptr, const unsigned char *maxPt
     crch.update(&ptr[0], count);
     CHECKPTR(&ptr[count], maxPtr, 1);
     if(ptr[count++]!=crch.getValue()) {
-        throw "Wrong checksum in BitSequence375 Header.";
+        throw std::runtime_error("Wrong checksum in BitSequence375 Header.");
     }
 
     // Read buffer
     this->numwords = numWords(numbits);
     size_t sizeBytes = numBytes(numbits);
     if(&ptr[count+sizeBytes]>=maxPtr) {
-        throw "BitSequence375 tries to read beyond the end of the file";
+        throw std::runtime_error("BitSequence375 tries to read beyond the end of the file");
     }
 
     array = (size_t *) &ptr[count];
@@ -258,7 +258,7 @@ BitSequence375 * BitSequence375::load(istream & in)
 	unsigned char type;
 	in.read((char*)&type, sizeof(type));
 	if(type!=TYPE_BITMAP_PLAIN) {    // throw exception
-        throw "Trying to read a BitmapPlain but the type does not match";
+        throw std::runtime_error("Trying to read a BitmapPlain but the type does not match");
 	}
 	crch.update(&type, sizeof(type));
 
@@ -267,7 +267,7 @@ BitSequence375 * BitSequence375::load(istream & in)
 	// Load number of total bits
 	uint64_t totalBits = csd::VByte::decode(in);
 	if(sizeof(size_t)==4 && totalBits>0xFFFFFFFF) {
-		throw "This File is too big to be processed using 32Bit version. Please compile with 64bit support";
+		throw std::runtime_error("This File is too big to be processed using 32Bit version. Please compile with 64bit support");
 	}
 	ret->numbits = (size_t) totalBits;
 
@@ -276,7 +276,7 @@ BitSequence375 * BitSequence375::load(istream & in)
 	crch.update(arr,len);
 	crc8_t filecrch = crc8_read(in);
 	if(filecrch!=crch.getValue()) {
-		throw "Wrong checksum in BitSequence375 Header.";
+		throw std::runtime_error("Wrong checksum in BitSequence375 Header.");
 	}
 
 	// Calculate numWords and create array
@@ -288,13 +288,13 @@ BitSequence375 * BitSequence375::load(istream & in)
 	size_t bytes = ret->numBytes(ret->numbits);
 	in.read((char*)&ret->data[0], bytes);
 	if(in.gcount()!=bytes) {
-		throw "BitSequence375 error reading array of bits.";
+		throw std::runtime_error("BitSequence375 error reading array of bits.");
 	}
 
 	crcd.update((unsigned char*)&ret->data[0], bytes);
 	crc32_t filecrcd = crc32_read(in);
 	if(filecrcd!=crcd.getValue()) {
-		throw "Wrong checksum in BitSequence375 Data.";
+		throw std::runtime_error("Wrong checksum in BitSequence375 Data.");
 	}
 
 	ret->buildIndex();
@@ -309,7 +309,7 @@ size_t BitSequence375::getSizeBytes() const
 
 size_t BitSequence375::selectPrev1(const size_t start) const
 {
-	throw "BitSequence375 selectPrev1 Not implemented";
+	throw std::runtime_error("BitSequence375 selectPrev1 Not implemented");
 	return 0;
 }
 
@@ -384,7 +384,7 @@ size_t BitSequence375::select1(const size_t x) const
 
 size_t BitSequence375::select0(const size_t x1) const
 {
-	throw "Not implemented";
+	throw std::runtime_error("Not implemented");
 	// FIXME Try on 64Bit.
 //	if(!indexReady) {
 //		(const_cast<BitSequence375 *>(this))->buildIndex();

--- a/hdt-lib/src/dictionary/FourSectionDictionary.cpp
+++ b/hdt-lib/src/dictionary/FourSectionDictionary.cpp
@@ -145,7 +145,7 @@ void FourSectionDictionary::load(std::istream & input, ControlInformation & ci, 
 {
 	std::string format = ci.getFormat();
 	if(format!=getType()) {
-		throw "Trying to read a FourSectionDictionary but the data is not FourSectionDictionary";
+		throw std::runtime_error("Trying to read a FourSectionDictionary but the data is not FourSectionDictionary");
 	}
 	//this->mapping = ci.getUint("mapping");
 	this->mapping = MAPPING2;
@@ -159,7 +159,7 @@ void FourSectionDictionary::load(std::istream & input, ControlInformation & ci, 
 	shared = csd::CSD::load(input);
 	if(shared==NULL){
 		shared = new csd::CSD_PFC();
-		throw "Could not read shared.";
+		throw std::runtime_error("Could not read shared.");
 	}
 	//shared = new csd::CSD_Cache(shared);
 
@@ -169,7 +169,7 @@ void FourSectionDictionary::load(std::istream & input, ControlInformation & ci, 
 	subjects = csd::CSD::load(input);
 	if(subjects==NULL){
 		subjects = new csd::CSD_PFC();
-		throw "Could not read subjects.";
+		throw std::runtime_error("Could not read subjects.");
 	}
 	//subjects = new csd::CSD_Cache(subjects);
 
@@ -179,7 +179,7 @@ void FourSectionDictionary::load(std::istream & input, ControlInformation & ci, 
 	predicates = csd::CSD::load(input);
 	if(predicates==NULL){
 		predicates = new csd::CSD_PFC();
-		throw "Could not read predicates.";
+		throw std::runtime_error("Could not read predicates.");
 	}
 	predicates = new csd::CSD_Cache2(predicates);
 
@@ -189,7 +189,7 @@ void FourSectionDictionary::load(std::istream & input, ControlInformation & ci, 
 	objects = csd::CSD::load(input);
 	if(objects==NULL){
 		objects = new csd::CSD_PFC();
-		throw "Could not read objects.";
+		throw std::runtime_error("Could not read objects.");
 	}
 	//objects = new csd::CSD_Cache(objects);
 }
@@ -212,7 +212,7 @@ size_t FourSectionDictionary::load(unsigned char *ptr, unsigned char *ptrMax, Pr
     shared = csd::CSD::create(ptr[count]);
     if(shared==NULL){
         shared = new csd::CSD_PFC();
-        throw "Could not read shared.";
+        throw std::runtime_error("Could not read shared.");
     }
     count += shared->load(&ptr[count], ptrMax);
     //shared = new csd::CSD_Cache(shared);
@@ -223,7 +223,7 @@ size_t FourSectionDictionary::load(unsigned char *ptr, unsigned char *ptrMax, Pr
     subjects = csd::CSD::create(ptr[count]);
     if(subjects==NULL){
         subjects = new csd::CSD_PFC();
-        throw "Could not read subjects.";
+        throw std::runtime_error("Could not read subjects.");
     }
     count += subjects->load(&ptr[count], ptrMax);
     //subjects = new csd::CSD_Cache(subjects);
@@ -234,7 +234,7 @@ size_t FourSectionDictionary::load(unsigned char *ptr, unsigned char *ptrMax, Pr
     predicates = csd::CSD::create(ptr[count]);
     if(predicates==NULL){
         predicates = new csd::CSD_PFC();
-        throw "Could not read predicates.";
+        throw std::runtime_error("Could not read predicates.");
     }
     count += predicates->load(&ptr[count], ptrMax);
     predicates = new csd::CSD_Cache2(predicates);
@@ -245,7 +245,7 @@ size_t FourSectionDictionary::load(unsigned char *ptr, unsigned char *ptrMax, Pr
     objects = csd::CSD::create(ptr[count]);
     if(objects==NULL){
         objects = new csd::CSD_PFC();
-        throw "Could not read objects.";
+        throw std::runtime_error("Could not read objects.");
     }
     count += objects->load(&ptr[count], ptrMax);
     //objects = new csd::CSD_Cache(objects);
@@ -289,7 +289,7 @@ void FourSectionDictionary::import(Dictionary *other, ProgressListener *listener
 
 		this->sizeStrings = other->size();
 		this->mapping = other->getMapping();
-	} catch (const char *e) {
+	} catch (std::exception& e) {
 		delete subjects;
 		delete predicates;
 		delete objects;
@@ -298,7 +298,7 @@ void FourSectionDictionary::import(Dictionary *other, ProgressListener *listener
 		predicates = new csd::CSD_PFC();
 		objects = new csd::CSD_PFC();
 		shared = new csd::CSD_PFC();
-		throw e;
+		throw;
 	}
 }
 
@@ -455,7 +455,7 @@ csd::CSD *FourSectionDictionary::getDictionarySection(unsigned int id, TripleCom
 		}
 	}
 
-	throw "Item not found";
+	throw std::runtime_error("Item not found");
 }
 
 unsigned int FourSectionDictionary::getGlobalId(unsigned int mapping, unsigned int id, DictionarySection position) {
@@ -478,7 +478,7 @@ unsigned int FourSectionDictionary::getGlobalId(unsigned int mapping, unsigned i
 		return id;
 	}
 
-	throw "Item not found";
+	throw std::runtime_error("Item not found");
 }
 
 
@@ -510,7 +510,7 @@ unsigned int FourSectionDictionary::getLocalId(unsigned int mapping, unsigned in
 		return id;
 	}
 
-	throw "Item not found";
+	throw std::runtime_error("Item not found");
 }
 
 unsigned int FourSectionDictionary::getLocalId(unsigned int id, TripleComponentRole position) {
@@ -542,6 +542,3 @@ void FourSectionDictionary::getSuggestions(const char *base, hdt::TripleComponen
 }
 
 }
-
-
-

--- a/hdt-lib/src/dictionary/KyotoDictionary.cpp
+++ b/hdt-lib/src/dictionary/KyotoDictionary.cpp
@@ -92,7 +92,7 @@ KyotoDictionary::~KyotoDictionary() {
 
 std::string KyotoDictionary::idToString(unsigned int id, TripleComponentRole position)
 {
-	throw "Not implemented";
+	throw std::logic_error("Not implemented");
 }
 
 unsigned int KyotoDictionary::stringToId(std::string &key, TripleComponentRole position)
@@ -250,7 +250,7 @@ void KyotoDictionary::stopProcessing(ProgressListener *listener)
 	}
 	delete curSubj;
 	delete curObj;
-#else 
+#else
 	// For each Subject, check object.
 	DB::Cursor* cur = subjects.cursor();
 	cur->jump();
@@ -307,22 +307,22 @@ void KyotoDictionary::stopProcessing(ProgressListener *listener)
 void KyotoDictionary::save(std::ostream &output, ControlInformation &controlInformation, ProgressListener *listener)
 {
 
-	throw "Not implemented";
+	throw std::logic_error("Not implemented");
 }
 
 size_t KyotoDictionary::load(unsigned char *ptr, unsigned char *ptrMax, ProgressListener *listener) {
-	throw "Not implemented";
+	throw std::logic_error("Not implemented");
 }
 
 void KyotoDictionary::load(std::istream & input, ControlInformation &ci, ProgressListener *listener)
 {
-	throw "Not implemented";
+	throw std::logic_error("Not implemented");
 
 }
 
 void KyotoDictionary::import(Dictionary *other, ProgressListener *listener) {
 
-	throw "Not implemented";
+	throw std::logic_error("Not implemented");
 }
 
 IteratorUCharString *KyotoDictionary::getSubjects() {
@@ -390,7 +390,7 @@ unsigned int KyotoDictionary::getGlobalId(unsigned int mapping, unsigned int id,
 			return id+1;
 		}
 
-		throw "Item not found";
+		throw std::runtime_error("Item not found");
 }
 
 
@@ -422,7 +422,7 @@ unsigned int KyotoDictionary::getLocalId(unsigned int mapping, unsigned int id, 
 			return id-1;
 		}
 
-		throw "Item not found";
+		throw std::runtime_error("Item not found");
 }
 
 unsigned int KyotoDictionary::getLocalId(unsigned int id, TripleComponentRole position) {
@@ -514,11 +514,10 @@ unsigned int KyotoDictionary::getMapping() {
 
 void KyotoDictionary::getSuggestions(const char *base, hdt::TripleComponentRole role, std::vector<std::string> &out, int maxResults)
 {
-    throw "getSuggestions not implemented";
+    throw std::logic_error("getSuggestions not implemented");
 }
 
 
 }
 
 #endif
-

--- a/hdt-lib/src/dictionary/LiteralDictionary.cpp
+++ b/hdt-lib/src/dictionary/LiteralDictionary.cpp
@@ -157,7 +157,7 @@ unsigned int LiteralDictionary::stringToId(std::string &key, TripleComponentRole
 void LiteralDictionary::load(std::istream & input, ControlInformation & ci,	ProgressListener *listener) {
 	std::string format = ci.getFormat();
 	if(format!=getType()) {
-		throw "Trying to read a LiteralDictionary but the data is not LiteralDictionary";
+		throw std::runtime_error("Trying to read a LiteralDictionary but the data is not LiteralDictionary");
 	}
 	this->mapping = ci.getUint("mapping");
 	this->sizeStrings = ci.getUint("sizeStrings");
@@ -170,7 +170,7 @@ void LiteralDictionary::load(std::istream & input, ControlInformation & ci,	Prog
 	shared = csd::CSD::load(input);
 	if (shared == NULL) {
 		shared = new csd::CSD_PFC();
-		throw "Could not read shared sectionsss.";
+		throw std::runtime_error("Could not read shared sectionsss.");
 	}
 
 	iListener.setRange(25, 50);
@@ -179,7 +179,7 @@ void LiteralDictionary::load(std::istream & input, ControlInformation & ci,	Prog
 	subjects = csd::CSD::load(input);
 	if (subjects == NULL) {
 		subjects = new csd::CSD_PFC();
-		throw "Could not read subjects.";
+		throw std::runtime_error("Could not read subjects.");
 	}
 	subjects = new csd::CSD_Cache(subjects);
 
@@ -190,7 +190,7 @@ void LiteralDictionary::load(std::istream & input, ControlInformation & ci,	Prog
 	predicates = csd::CSD::load(input);
 	if (predicates == NULL) {
 		predicates = new csd::CSD_PFC();
-		throw "Could not read predicates.";
+		throw std::runtime_error("Could not read predicates.");
 	}
 	predicates = new csd::CSD_Cache2(predicates);
 
@@ -201,7 +201,7 @@ void LiteralDictionary::load(std::istream & input, ControlInformation & ci,	Prog
 	objectsLiterals = csd::CSD::load(input);
 	if (objectsLiterals == NULL) {
 		objectsLiterals = new csd::CSD_FMIndex();
-		throw "Could not read objects Literals.";
+		throw std::runtime_error("Could not read objects Literals.");
 	}
 	objectsLiterals = new csd::CSD_Cache(objectsLiterals);
 
@@ -209,7 +209,7 @@ void LiteralDictionary::load(std::istream & input, ControlInformation & ci,	Prog
 	objectsNotLiterals = csd::CSD::load(input);
 	if (objectsNotLiterals == NULL) {
 		objectsNotLiterals = new csd::CSD_PFC();
-		throw "Could not read objects not Literals.";
+		throw std::runtime_error("Could not read objects not Literals.");
 	}
     objectsNotLiterals = new csd::CSD_Cache(objectsNotLiterals);
 }
@@ -231,7 +231,7 @@ size_t LiteralDictionary::load(unsigned char *ptr, unsigned char *ptrMax, Progre
     shared = csd::CSD::create(ptr[count]);
     if(shared==NULL){
         shared = new csd::CSD_PFC();
-        throw "Could not read shared.";
+        throw std::runtime_error("Could not read shared.");
     }
     count += shared->load(&ptr[count], ptrMax);
     shared = new csd::CSD_Cache(shared);
@@ -242,7 +242,7 @@ size_t LiteralDictionary::load(unsigned char *ptr, unsigned char *ptrMax, Progre
     subjects = csd::CSD::create(ptr[count]);
     if(subjects==NULL){
         subjects = new csd::CSD_PFC();
-        throw "Could not read subjects.";
+        throw std::runtime_error("Could not read subjects.");
     }
     count += subjects->load(&ptr[count], ptrMax);
     subjects = new csd::CSD_Cache(subjects);
@@ -253,7 +253,7 @@ size_t LiteralDictionary::load(unsigned char *ptr, unsigned char *ptrMax, Progre
     predicates = csd::CSD::create(ptr[count]);
     if(predicates==NULL){
         predicates = new csd::CSD_PFC();
-        throw "Could not read predicates.";
+        throw std::runtime_error("Could not read predicates.");
     }
     count += predicates->load(&ptr[count], ptrMax);
     predicates = new csd::CSD_Cache(predicates);
@@ -264,7 +264,7 @@ size_t LiteralDictionary::load(unsigned char *ptr, unsigned char *ptrMax, Progre
     objectsLiterals = csd::CSD::create(ptr[count]);
     if(objectsLiterals==NULL){
         objectsLiterals = new csd::CSD_PFC();
-        throw "Could not read object Literals.";
+        throw std::runtime_error("Could not read object Literals.");
     }
     count += objectsLiterals->load(&ptr[count], ptrMax);
     objectsLiterals = new csd::CSD_Cache(objectsLiterals);
@@ -275,7 +275,7 @@ size_t LiteralDictionary::load(unsigned char *ptr, unsigned char *ptrMax, Progre
     objectsNotLiterals = csd::CSD::create(ptr[count]);
     if(objectsNotLiterals==NULL){
         objectsNotLiterals = new csd::CSD_PFC();
-        throw "Could not read objects Not Literals.";
+        throw std::runtime_error("Could not read objects Not Literals.");
     }
     count += objectsNotLiterals->load(&ptr[count], ptrMax);
     objectsNotLiterals = new csd::CSD_Cache(objectsNotLiterals);
@@ -376,7 +376,7 @@ void LiteralDictionary::import(	Dictionary *other, ProgressListener *listener) {
 
 		this->sizeStrings = other->size();
 		this->mapping = other->getMapping();
-	} catch (const char *e) {
+	} catch (std::exception& e) {
 		delete subjects;
 		delete predicates;
 		delete objectsLiterals;
@@ -387,24 +387,24 @@ void LiteralDictionary::import(	Dictionary *other, ProgressListener *listener) {
 		objectsNotLiterals = new csd::CSD_PFC();
 		objectsLiterals = new csd::CSD_FMIndex();
 		shared = new csd::CSD_PFC();
-		throw e;
+		throw;
 	}
 }
 
 IteratorUCharString *LiteralDictionary::getSubjects() {
-	throw "Not implemented";
+	throw std::logic_error("Not implemented");
 }
 
 IteratorUCharString *LiteralDictionary::getPredicates() {
-	throw "Not implemented";
+	throw std::logic_error("Not implemented");
 }
 
 IteratorUCharString *LiteralDictionary::getObjects() {
-	throw "Not implemented";
+	throw std::logic_error("Not implemented");
 }
 
 IteratorUCharString *LiteralDictionary::getShared() {
-	throw "Not implemented";
+	throw std::logic_error("Not implemented");
 }
 
 uint32_t LiteralDictionary::substringToId(unsigned char *s, uint32_t len, uint32_t **occs){
@@ -557,7 +557,7 @@ void LiteralDictionary::stopProcessing(ProgressListener *listener) {
 
 unsigned int LiteralDictionary::insert(std::string & str,
 		TripleComponentRole position) {
-	throw "This dictionary does not support insertions.";
+	throw std::runtime_error("This dictionary does not support insertions.");
 }
 
 string LiteralDictionary::getType() {
@@ -603,7 +603,7 @@ csd::CSD *LiteralDictionary::getDictionarySection(unsigned int id, TripleCompone
 		}
 	}
 
-	throw "Item not found";
+	throw std::runtime_error("Item not found");
 }
 
 unsigned int LiteralDictionary::getGlobalId(unsigned int mapping, unsigned int id, DictionarySection position) {
@@ -626,7 +626,7 @@ unsigned int LiteralDictionary::getGlobalId(unsigned int mapping, unsigned int i
 		return id;
 	}
 
-	throw "Item not found";
+	throw std::runtime_error("Item not found");
 }
 
 unsigned int LiteralDictionary::getGlobalId(unsigned int id, DictionarySection position) {
@@ -666,7 +666,7 @@ unsigned int LiteralDictionary::getLocalId(unsigned int mapping, unsigned int id
 		return id;
 	}
 
-	throw "Item not found";
+	throw std::runtime_error("Item not found");
 }
 
 unsigned int LiteralDictionary::getLocalId(unsigned int id, TripleComponentRole position) {

--- a/hdt-lib/src/dictionary/PlainDictionary.cpp
+++ b/hdt-lib/src/dictionary/PlainDictionary.cpp
@@ -211,7 +211,7 @@ void PlainDictionary::load(std::istream & input, ControlInformation &ci, Progres
 
 	std::string format = ci.getFormat();
 	if(format!=getType()) {
-		throw "Trying to read a PlainDictionary but the data is not PlainDictionary";
+		throw std::runtime_error("Trying to read a PlainDictionary but the data is not PlainDictionary");
 	}
 
 	this->mapping = ci.getUint("mapping");
@@ -250,11 +250,11 @@ void PlainDictionary::load(std::istream & input, ControlInformation &ci, Progres
 
 size_t PlainDictionary::load(unsigned char *ptr, unsigned char *ptrMax, ProgressListener *listener)
 {
-    throw "Not implemented load";
+    throw std::logic_error("Not implemented load");
 }
 
 void PlainDictionary::import(Dictionary *other, ProgressListener *listener) {
-	throw "Not implemented import";
+	throw std::logic_error("Not implemented import");
 }
 
 IteratorUCharString *PlainDictionary::getSubjects() {
@@ -549,7 +549,7 @@ vector<DictionaryEntry*> &PlainDictionary::getDictionaryEntryVector(unsigned int
 		}
 	}
 
-	throw "Item not found";
+	throw std::runtime_error("Item not found");
 }
 
 unsigned int PlainDictionary::getGlobalId(unsigned int mapping, unsigned int id, DictionarySection position) {
@@ -572,7 +572,7 @@ unsigned int PlainDictionary::getGlobalId(unsigned int mapping, unsigned int id,
 			return id+1;
 		}
 
-		throw "Item not found";
+		throw std::runtime_error("Item not found");
 }
 
 
@@ -604,7 +604,7 @@ unsigned int PlainDictionary::getLocalId(unsigned int mapping, unsigned int id, 
 			return id-1;
 		}
 
-		throw "Item not found";
+		throw std::runtime_error("Item not found");
 }
 
 unsigned int PlainDictionary::getLocalId(unsigned int id, TripleComponentRole position) {
@@ -712,7 +712,7 @@ unsigned int PlainDictionary::getMapping() {
 
 void PlainDictionary::getSuggestions(const char *base, hdt::TripleComponentRole role, std::vector<std::string> &out, int maxResults)
 {
-    throw "getSuggestions not implemented";
+    throw std::logic_error("getSuggestions not implemented");
 }
 
 }

--- a/hdt-lib/src/hdt/BasicHDT.cpp
+++ b/hdt-lib/src/hdt/BasicHDT.cpp
@@ -99,7 +99,7 @@ void BasicHDT::createComponents() {
 	try{
 		spec.get("dictionary.type");
 	}
-	catch (exception& e){
+	catch (std::exception& e){
 	}
 
 	if(dictType==HDTVocabulary::DICTIONARY_TYPE_FOUR) {
@@ -110,7 +110,7 @@ void BasicHDT::createComponents() {
 #ifdef HAVE_CDS
 		dictionary = new LiteralDictionary(spec);
 #else
-		throw "This version has been compiled without support for this dictionary";
+		throw std::runtime_error("This version has been compiled without support for this dictionary");
 #endif
 	} else {
 		dictionary = new FourSectionDictionary(spec);
@@ -120,7 +120,7 @@ void BasicHDT::createComponents() {
 	std::string triplesType = "";
 	try{
 		triplesType = spec.get("triples.type");
-	}catch (exception& e) {
+	}catch (std::exception& e) {
 	}
 	if(triplesType==HDTVocabulary::TRIPLES_TYPE_BITMAP) {
 		triples = new BitmapTriples(spec);
@@ -178,8 +178,8 @@ IteratorTripleString* BasicHDT::search(const char* subject,	const char* predicat
 		IteratorTripleID* iterID = triples->search(tid);
 		TripleIDStringIterator* iterator = new TripleIDStringIterator(dictionary, iterID);
 		return iterator;
-	} catch (char* e) {
-		cout << "Exception: " << e << endl;
+	} catch (std::exception& e) {
+		cerr << "Exception: " << e.what() << endl;
 	}
 	return new IteratorTripleString();
 }
@@ -240,15 +240,10 @@ void BasicHDT::loadDictionary(const char* fileName, const char* baseUri, RDFNota
 		else{
 			dictionary = dict;
 		}
-
-	} catch (const char *e) {
-		cout << "Catch exception dictionary: " << e << endl;
+	} catch(exception& e) {
+		cerr << "caught here??" << endl;
 		delete dict;
-		throw e;
-	} catch (char *e) {
-		cout << "Catch exception dictionary: " << e << endl;
-		delete dict;
-		throw e;
+		throw;
 	}
 }
 
@@ -258,7 +253,9 @@ void TriplesLoader::processTriple(hdt::TripleString& triple, unsigned long long 
 	if (ti.isValid()) {
 		triples->insert(ti);
 	} else {
-		cerr << "ERROR: Could not convert triple to IDS! " << endl << triple << endl << ti << endl;
+		stringstream msg;
+		msg << "ERROR: Could not convert triple to IDS! " << endl << triple << endl << ti;
+		throw ParseException(msg.str());
 	}
 	//cout << "TripleID: " << ti << endl;
 	char str[100];
@@ -298,7 +295,7 @@ void BasicHDT::loadTriples(const char* fileName, const char* baseUri, RDFNotatio
 		string ord = "";
 		try{
 			ord = spec.get("triplesOrder");
-		}catch (exception& e){
+		}catch (std::exception& e){
 		}
 		TripleComponentOrder order = parseOrder(
 				ord.c_str());
@@ -311,14 +308,10 @@ void BasicHDT::loadTriples(const char* fileName, const char* baseUri, RDFNotatio
 
 		iListener.setRange(85, 90);
 		triplesList->removeDuplicates(&iListener);
-	} catch (const char *e) {
-		cout << "Catch exception triples" << e << endl;
+	} catch (std::exception& e) {
+		// cout << "Catch exception triples" << e << endl;
 		delete triplesList;
-		throw e;
-	} catch (char *e) {
-		cout << "Catch exception triples" << e << endl;
-		delete triplesList;
-		throw e;
+		throw;
 	}
 	if (triples->getType() == triplesList->getType()) {
 		delete triples;
@@ -327,9 +320,9 @@ void BasicHDT::loadTriples(const char* fileName, const char* baseUri, RDFNotatio
 		iListener.setRange(90, 100);
 		try {
 			triples->load(*triplesList, &iListener);
-		} catch (const char* e) {
+		} catch (std::exception& e) {
 			delete triplesList;
-			throw e;
+			throw;
 		}
 		delete triplesList;
 	}
@@ -404,16 +397,11 @@ void BasicHDT::loadFromRDF(const char *fileName, string baseUri, RDFNotation not
 
 		fillHeader(baseUri);
 
-	}catch (const char *e) {
-		cout << "Catch exception load: " << e << endl;
+	}catch (std::exception& e) {
+		cout << "Catch exception load: " << e.what() << endl;
 		deleteComponents();
 		createComponents();
-		throw e;
-	} catch (char *e) {
-		cout << "Catch exception load: " << e << endl;
-		deleteComponents();
-		createComponents();
-		throw e;
+		throw;
 	}
 }
 
@@ -477,14 +465,10 @@ void BasicHDT::loadDictionaryFromHDTs(const char** fileName, size_t numFiles, co
         	dictionary->import(dict);
 
         	delete dict;
-        } catch (const char *e) {
-        	cout << "Catch exception dictionary: " << e << endl;
+        } catch (std::exception& e) {
+        	cerr << "Catch exception dictionary: " << e.what() << endl;
         	delete dict;
-        	throw e;
-        } catch (char *e) {
-        	cout << "Catch exception dictionary: " << e << endl;
-        	delete dict;
-        	throw e;
+        	throw;
         }
 }
 
@@ -577,7 +561,7 @@ void BasicHDT::loadTriplesFromHDTs(const char** fileNames, size_t numFiles, cons
 		try{
 			ord = spec.get("triplesOrder");
 		}
-		catch (exception& e){
+		catch (std::exception& e){
 		}
 		TripleComponentOrder order = parseOrder(ord.c_str());
 		if (order == Unknown) {
@@ -591,14 +575,10 @@ void BasicHDT::loadTriplesFromHDTs(const char** fileNames, size_t numFiles, cons
 		triplesList->removeDuplicates(&iListener);
 
 		header->insert("_:statistics", HDTVocabulary::ORIGINAL_SIZE, totalOriginalSize);
-	} catch (const char *e) {
-		cout << "Catch exception triples" << e << endl;
+	} catch (std::exception& e) {
+		// cout << "Catch exception triples" << e << endl;
 		delete triplesList;
-		throw e;
-	} catch (char *e) {
-		cout << "Catch exception triples" << e << endl;
-		delete triplesList;
-		throw e;
+		throw;
 	}
 	if (triples->getType() == triplesList->getType()) {
 		delete triples;
@@ -607,9 +587,9 @@ void BasicHDT::loadTriplesFromHDTs(const char** fileNames, size_t numFiles, cons
 		iListener.setRange(90, 100);
 		try {
 			triples->load(*triplesList, &iListener);
-		} catch (const char* e) {
+		} catch (std::exception& e) {
 			delete triplesList;
-			throw e;
+			throw;
 		}
 		delete triplesList;
 	}
@@ -637,16 +617,11 @@ void BasicHDT::loadFromSeveralHDT(const char **fileNames, size_t numFiles, strin
 
 		fillHeader(baseUri);
 
-	}catch (const char *e) {
-		cout << "Catch exception load: " << e << endl;
+	}catch (std::exception& e) {
+		// cout << "Catch exception load: " << e << endl;
 		deleteComponents();
 		createComponents();
-		throw e;
-	} catch (char *e) {
-		cout << "Catch exception load: " << e << endl;
-		deleteComponents();
-		createComponents();
-		throw e;
+		throw;
 	}
 }
 
@@ -655,13 +630,7 @@ void BasicHDT::loadFromSeveralHDT(const char **fileNames, size_t numFiles, strin
 void BasicHDT::saveToRDF(RDFSerializer &serializer, ProgressListener *listener)
 {
 	IteratorTripleString *it = search("", "", "");
-        try {
-            serializer.serialize(it, listener, getTriples()->getNumberOfElements());
-        } catch (const char *e) {
-            throw e;
-        } catch (char *e) {
-            throw e;
-        }
+  serializer.serialize(it, listener, getTriples()->getNumberOfElements());
 	delete it;
 }
 
@@ -671,7 +640,7 @@ void BasicHDT::loadFromHDT(const char *fileName, ProgressListener *listener) {
 	DecompressStream stream(fileName);
 	istream *in = stream.getStream();
 	if(!in->good()){
-		throw "Error opening file to load HDT.";
+		throw std::runtime_error("Error opening file to load HDT.");
 	}
 	this->loadFromHDT(*in, listener);
 	stream.close();
@@ -687,7 +656,7 @@ void BasicHDT::loadFromHDT(std::istream & input, ProgressListener *listener)
 	controlInformation.load(input);
 	std::string hdtFormat = controlInformation.getFormat();
 	if(hdtFormat!=HDTVocabulary::HDT_CONTAINER) {
-		throw "This software cannot open this version of HDT File.";
+		throw std::runtime_error("This software cannot open this version of HDT File.");
 	}
 
 	// Load header
@@ -710,16 +679,11 @@ void BasicHDT::loadFromHDT(std::istream & input, ProgressListener *listener)
 	delete triples;
 	triples = HDTFactory::readTriples(controlInformation);
 	triples->load(input, controlInformation, &iListener);
-    } catch (const char *ex) {
-        cout << "Exception loading HDT: " << ex;
+    } catch (std::exception& e) {
+        // cout << "Exception loading HDT: " << ex;
         deleteComponents();
         createComponents();
-        throw ex;
-    } catch (char *ex) {
-    	cout << "Exception loading HDT: " << ex;
-    	deleteComponents();
-        createComponents();
-        throw ex;
+        throw;
     }
 }
 
@@ -749,7 +713,7 @@ void BasicHDT::mapHDT(const char *fileNameChar, ProgressListener *listener) {
                 iListener.setRange(80,100);
             }
         #else
-            throw "Support for GZIP was not compiled in this version. Please decompress the file before opening it.";
+            throw std::runtime_error("Support for GZIP was not compiled in this version. Please decompress the file before opening it.");
         #endif
     } else {
         this->fileName.assign(fileNameChar);
@@ -778,7 +742,7 @@ size_t BasicHDT::loadMMap(unsigned char *ptr, unsigned char *ptrMax, ProgressLis
     count+=controlInformation.load(&ptr[count], ptrMax);
     std::string hdtFormat = controlInformation.getFormat();
     if(hdtFormat!=HDTVocabulary::HDT_CONTAINER) {
-    	throw "This software cannot open this version of HDT File.";
+    	throw std::runtime_error("This software cannot open this version of HDT File.");
     }
 
     // Load Header
@@ -829,15 +793,15 @@ void BasicHDT::saveToHDT(const char *fileName, ProgressListener *listener)
     try {
         ofstream out(fileName, ios::binary | ios::out | ios::trunc);
         if(!out.good()){
-            throw "Error opening file to save HDT.";
+            throw std::runtime_error("Error opening file to save HDT.");
         }
         this->fileName = fileName;
         this->saveToHDT(out, listener);
         this->saveIndex(listener);
         out.close();
-    } catch (const char *ex) {
+    } catch (std::exception& e) {
         // Fixme: delete file if exists.
-        throw ex;
+        throw;
     }
 
     this->fileName = fileName;

--- a/hdt-lib/src/hdt/BasicModifiableHDT.cpp
+++ b/hdt-lib/src/hdt/BasicModifiableHDT.cpp
@@ -31,7 +31,7 @@ void BasicModifiableHDT::createComponents() {
 		std::string dictType = spec.get("dictionary.type");
 		std::string triplesType = spec.get("triples.type");
 	}
-	 catch (exception& e)
+	 catch (std::exception& e)
 	  {
 	  }
 
@@ -76,7 +76,7 @@ IteratorTripleString *BasicModifiableHDT::search(const char *subject, const char
 
 VarBindingString *BasicModifiableHDT::searchJoin(vector<TripleString> &patterns, set<string> &vars)
 {
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 void BasicModifiableHDT::loadFromRDF(const char *fileName, string baseUri, RDFNotation notation, ProgressListener *listener)
@@ -94,7 +94,7 @@ void BasicModifiableHDT::saveToRDF(RDFSerializer &serializer, ProgressListener *
 void BasicModifiableHDT::loadFromHDT(const char *fileName, ProgressListener *listener) {
 	ifstream input(fileName, ios::binary | ios::in);
 	if(!input.good()){
-		throw "Error opening file to save HDT.";
+		throw std::runtime_error("Error opening file to save HDT.");
 	}
 	this->loadFromHDT(input, listener);
     input.close();
@@ -102,7 +102,7 @@ void BasicModifiableHDT::loadFromHDT(const char *fileName, ProgressListener *lis
 
 void BasicModifiableHDT::mapHDT(const char *fileName, ProgressListener *listener)
 {
-    throw "Not implemented";
+    throw std::logic_error("Not Implemented");
 }
 
 void BasicModifiableHDT::loadFromHDT(std::istream & input, ProgressListener *listener)
@@ -129,7 +129,7 @@ void BasicModifiableHDT::saveToHDT(const char *fileName, ProgressListener *liste
 {
 	ofstream out(fileName, ios::binary | ios::out);
 	if(!out.good()){
-		throw "Error opening file to save HDT.";
+		throw std::runtime_error("Error opening file to save HDT.");
 	}
 	this->saveToHDT(out, listener);
 	out.close();
@@ -166,7 +166,7 @@ void BasicModifiableHDT::insert(TripleString & triple)
 
 void BasicModifiableHDT::insert(IteratorTripleString *triples)
 {
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 void BasicModifiableHDT::remove(TripleString & triple)
@@ -180,7 +180,7 @@ void BasicModifiableHDT::remove(TripleString & triple)
 
 void BasicModifiableHDT::remove(IteratorTripleString *triples)
 {
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 }

--- a/hdt-lib/src/hdt/ControlInformation.cpp
+++ b/hdt-lib/src/hdt/ControlInformation.cpp
@@ -83,7 +83,7 @@ void ControlInformation::load(std::istream &in) {
 	crc.readData(in, hdt, 4);
 	hdt[4]=0;
     if(strncmp((char*)hdt,"$HDT",4)!=0) {
-		throw "Non-HDT Section";
+		throw std::runtime_error("Non-HDT Section");
 	}
 
     // Read type
@@ -118,11 +118,11 @@ void ControlInformation::load(std::istream &in) {
 
     // CRC16
     if(filecrc!=crc.getValue()) {
-		throw "CRC of control information does not match.";
+		throw std::runtime_error("CRC of control information does not match.");
 	}
 }
 
-#define CHECKPTR(base, max, size) if(((base)+(size))>(max)) throw "Could not read completely the HDT from the file.";
+#define CHECKPTR(base, max, size) if(((base)+(size))>(max)) throw std::runtime_error("Could not read completely the HDT from the file.");
 
 size_t ControlInformation::load(const unsigned char *ptr, const unsigned char *maxPtr) {
     this->clear();
@@ -132,7 +132,7 @@ size_t ControlInformation::load(const unsigned char *ptr, const unsigned char *m
 	// $HDT
 	CHECKPTR(ptr,maxPtr, 5);
 	if(strncmp((char *)&ptr[count],"$HDT", 4)!=0) {
-		throw "Non-HDT Section";
+		throw std::runtime_error("Non-HDT Section");
 	}
 	count+=4;
 
@@ -178,7 +178,7 @@ size_t ControlInformation::load(const unsigned char *ptr, const unsigned char *m
 	CHECKPTR(ptr,maxPtr, sizeof(crc16_t));
 	const crc16_t filecrc = *((crc16_t *)&ptr[count]);
 	if(filecrc!=crc.getValue()) {
-		throw "CRC of control information does not match.";
+		throw std::runtime_error("CRC of control information does not match.");
 	}
 	count+=sizeof(crc16_t);
 

--- a/hdt-lib/src/hdt/HDTFactory.cpp
+++ b/hdt-lib/src/hdt/HDTFactory.cpp
@@ -96,7 +96,7 @@ Triples *HDTFactory::readTriples(ControlInformation &controlInformation) {
 #endif
 	}
 
-	throw "Triples Implementation not available";
+	throw std::runtime_error("Triples Implementation not available");
 }
 
 Dictionary *HDTFactory::readDictionary(ControlInformation &controlInformation) {
@@ -111,16 +111,16 @@ Dictionary *HDTFactory::readDictionary(ControlInformation &controlInformation) {
 #ifdef HAVE_CDS
 		return new LiteralDictionary();
 #else
-		throw "This version has been compiled without support for this dictionary";
+		throw std::runtime_error("This version has been compiled without support for this dictionary");
 #endif
 	}
 
-	throw "Dictionary Implementation not available";
+	throw std::runtime_error("Dictionary Implementation not available");
 }
 
 Header *HDTFactory::readHeader(ControlInformation &controlInformation) {
     if(controlInformation.getType()!=HEADER)
-		throw "Trying to get Header from Non-Header section";
+		throw std::runtime_error("Trying to get Header from Non-Header section");
 
 	return new PlainHeader();
 }

--- a/hdt-lib/src/hdt/HDTSpecification.cpp
+++ b/hdt-lib/src/hdt/HDTSpecification.cpp
@@ -38,7 +38,7 @@ HDTSpecification::HDTSpecification(const std::string& filename) {
 	if(!filename.empty()){
 		try {
 			PropertyUtil::read(filename.c_str(), map);
-		} catch (char *except) {
+		} catch (std::exception& e) {
 			std::cerr << "WARNING: Could not read config file, using default options." << std::endl;
 		}
 	}

--- a/hdt-lib/src/header/PlainHeader.cpp
+++ b/hdt-lib/src/header/PlainHeader.cpp
@@ -54,14 +54,14 @@ void PlainHeader::load(std::istream & input, ControlInformation &controlInformat
 
 	// FIXME: Use format to create custom parser.
 	if(format!=HDTVocabulary::HEADER_NTRIPLES) {
-		throw "This Header format is not supported";
+		throw std::runtime_error("This Header format is not supported");
 	}
-	
+
 	// Read all header into a string
 	string str(headerSize,'\0');
 	input.read(&str[0], headerSize);
 	if(input.gcount()!=headerSize) {
-	    throw "Error reading header";
+	    throw std::runtime_error("Error reading header");
 	}
 
 	// Convert into a stringstream
@@ -89,7 +89,7 @@ size_t PlainHeader::load(unsigned char *ptr, unsigned char *ptrMax, ProgressList
 
 	// FIXME: Use format to create custom parser.
 	if(format!=HDTVocabulary::HEADER_NTRIPLES) {
-		throw "This Header format is not supported";
+		throw std::runtime_error("This Header format is not supported");
 	}
 
     string str(&ptr[count], &ptr[count+headerSize]);

--- a/hdt-lib/src/libdcs/CSD.cpp
+++ b/hdt-lib/src/libdcs/CSD.cpp
@@ -6,7 +6,7 @@
  *
  *   ==========================================================================
  *     "Compressed String Dictionaries"
- *     Nieves R. Brisaboa, Rodrigo Canovas, Francisco Claude, 
+ *     Nieves R. Brisaboa, Rodrigo Canovas, Francisco Claude,
  *     Miguel A. Martinez-Prieto and Gonzalo Navarro.
  *     10th Symposium on Experimental Algorithms (SEA'2011), p.136-147, 2011.
  *   ==========================================================================
@@ -55,20 +55,20 @@ CSD * CSD::load(istream & fp)
 {
     int type = fp.get();
     if(!fp.good()) {
-	throw "Error reading stream";
+	throw std::runtime_error("Error reading stream");
     }
     switch(type)
     {
-    case PFC: 
+    case PFC:
 	return CSD_PFC::load(fp);
 #ifdef HAVE_CDS
-    case FMINDEX: 
+    case FMINDEX:
 	return CSD_FMIndex::load(fp);
-    case HTFC: 
+    case HTFC:
 	return CSD_HTFC::load(fp);
 #endif
     default:
-	throw "No implementation for CSD";
+	throw std::logic_error("No implementation for CSD");
     }
     return NULL;
 }
@@ -82,7 +82,7 @@ CSD *CSD::create(unsigned char type)
     case HTFC: return new CSD_HTFC();
     case FMINDEX: return new CSD_FMIndex();
 #endif
-    default: throw "No implementation for CSD";
+    default: throw std::logic_error("No implementation for CSD");
     }
 
     return NULL;
@@ -94,5 +94,3 @@ uint32_t CSD::getLength()
 }
 
 }
-
-

--- a/hdt-lib/src/libdcs/CSD_Cache.cpp
+++ b/hdt-lib/src/libdcs/CSD_Cache.cpp
@@ -110,7 +110,7 @@ void CSD_Cache::save(ostream &fp)
 
 CSD* CSD_Cache::load(istream &fp)
 {
-	throw "Not imlemented";
+	throw std::logic_error("Not imlemented");
 }
 
 }

--- a/hdt-lib/src/libdcs/CSD_Cache2.cpp
+++ b/hdt-lib/src/libdcs/CSD_Cache2.cpp
@@ -94,7 +94,7 @@ void CSD_Cache2::save(ostream &fp)
 
 CSD* CSD_Cache2::load(istream &fp)
 {
-	throw "Not imlemented";
+	throw std::logic_error("Not imlemented");
 }
 
 }

--- a/hdt-lib/src/libdcs/CSD_FMIndex.h
+++ b/hdt-lib/src/libdcs/CSD_FMIndex.h
@@ -117,7 +117,7 @@ namespace csd{
 
 			void fillSuggestions(const char *base, vector<string> &out, int maxResults);
 
-		    hdt::IteratorUCharString *listAll() { throw "Not implemented"; }
+		    hdt::IteratorUCharString *listAll() { throw std::logic_error("Not Implemented"); }
 
 			/** General destructor. */
 			~CSD_FMIndex();

--- a/hdt-lib/src/libdcs/CSD_HTFC.cpp
+++ b/hdt-lib/src/libdcs/CSD_HTFC.cpp
@@ -428,7 +428,7 @@ void CSD_HTFC::save(ostream & fp)
 
 size_t CSD_HTFC::load(unsigned char *ptr, unsigned char *ptrMax)
 {
-    throw "Not implemented";
+    throw std::logic_error("Not Implemented");
 }
 
 CSD* CSD_HTFC::load(istream &fp)

--- a/hdt-lib/src/libdcs/CSD_HTFC.h
+++ b/hdt-lib/src/libdcs/CSD_HTFC.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2011, Rodrigo Canovas & Miguel A. Martinez-Prieto
  * all rights reserved.
  *
- * This class implements a VByte-oriented Front Coding technique for 
+ * This class implements a VByte-oriented Front Coding technique for
  * compression of string dictionaries.
  *
  * This library is free software; you can redistribute it and/or
@@ -61,8 +61,8 @@ typedef struct
 static const size_t DELTA = 5;        // Maxixum possible length for a VByte encoding delta.
 
 class CSD_HTFC : public CSD
-{		
-  public:		
+{
+  public:
     /** General constructor **/
     CSD_HTFC();
 
@@ -70,9 +70,9 @@ class CSD_HTFC : public CSD
 
     /** General destructor. */
     ~CSD_HTFC();
-    
-    /** Returns the ID that identify s[1..length]. If it does not exist, 
-	returns 0. 
+
+    /** Returns the ID that identify s[1..length]. If it does not exist,
+	returns 0.
 	@s: the string to be located.
 	@len: the length (in characters) of the string s.
     */
@@ -110,8 +110,8 @@ class CSD_HTFC : public CSD
     static CSD * load(istream & fp);
 
     void fillSuggestions(const char *base, vector<string> &out, int maxResults);
-		
-    hdt::IteratorUCharString *listAll() { throw "Not implemented"; }
+
+    hdt::IteratorUCharString *listAll() { throw std::logic_error("Not Implemented"); }
 
   protected:
     uint64_t bytes;	//! Size of the Front-Coding encoded sequence (in bytes).
@@ -138,8 +138,8 @@ class CSD_HTFC : public CSD
     */
     bool locateBlock(const uchar *s, uint *block);
 
-    /** Locates the offset for 's' in 'block' (returning its global ID) or 
-	return 0 if it is  not exist 
+    /** Locates the offset for 's' in 'block' (returning its global ID) or
+	return 0 if it is  not exist
 	@block: block to be queried.
 	@s: the required string.
 	@len: the length (in characters) of the string s.
@@ -208,4 +208,4 @@ class CSD_HTFC : public CSD
 };
 
 #endif
-#endif  
+#endif

--- a/hdt-lib/src/libdcs/CSD_PFC.cpp
+++ b/hdt-lib/src/libdcs/CSD_PFC.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2011, Rodrigo Canovas & Miguel A. Martinez-Prieto
  * all rights reserved.
  *
- * This class implements a VByte-oriented Front Coding technique for 
+ * This class implements a VByte-oriented Front Coding technique for
  * compression of string dictionaries.
  *
  * This library is free software; you can redistribute it and/or
@@ -255,7 +255,7 @@ CSD* CSD_PFC::load(istream & fp)
 
 	crc8_t filecrc = crc8_read(fp);
 	if(crch.getValue()!=filecrc) {
-		throw "Checksum error while reading Plain Front Coding Header.";
+		throw std::runtime_error("Checksum error while reading Plain Front Coding Header.");
 	}
 
 	// Load blocks
@@ -276,7 +276,7 @@ CSD* CSD_PFC::load(istream & fp)
 			counter += fp.gcount();
 		}
 		if(counter!=dicc->bytes) {
-			throw "Could not read all the data section of the Plain Front Coding.";
+			throw std::runtime_error("Could not read all the data section of the Plain Front Coding.");
 		}
 	} else {
 		// Make sure that all is zero.
@@ -289,7 +289,7 @@ CSD* CSD_PFC::load(istream & fp)
 
 	crc32_t filecrcd = crc32_read(fp);
 	if(filecrcd!=crcd.getValue()) {
-		throw "Checksum error in the data section of the Plain Front Coding.";
+		throw std::runtime_error("Checksum error in the data section of the Plain Front Coding.");
 	}
 
 	return dicc;
@@ -300,7 +300,7 @@ size_t CSD_PFC::load(unsigned char *ptr, unsigned char *ptrMax) {
 
 	// Type
 	if(ptr[count++] != PFC)
-		throw "Trying to read a CSD_PFC but type does not match";
+		throw std::runtime_error("Trying to read a CSD_PFC but type does not match");
 
 	count += VByte::decode(&ptr[count], ptrMax, &numstrings);
 	count += VByte::decode(&ptr[count], ptrMax, &bytes);
@@ -310,7 +310,7 @@ size_t CSD_PFC::load(unsigned char *ptr, unsigned char *ptrMax) {
 	CRC8 crch;
 	crch.update(&ptr[0], count);
 	if(crch.getValue()!=ptr[count++])
-		throw "CRC Error while reading CSD_PFC Header.";
+		throw std::runtime_error("CRC Error while reading CSD_PFC Header.");
 
 	// Blocks
     if(blocks) delete blocks;

--- a/hdt-lib/src/libdcs/VByte.cpp
+++ b/hdt-lib/src/libdcs/VByte.cpp
@@ -36,7 +36,7 @@ namespace csd
 	 * Returns the number of read bytes
 	 */
 	size_t VByte::encode(unsigned char *buffer, uint64_t value )
-	{		
+	{
 		size_t i= 0;
 
 		while (value>127)
@@ -45,13 +45,13 @@ namespace csd
 			i++;
 			value>>=7;
 		}
-		
+
 		buffer[i] = (unsigned char)(value|0x80);
 		i++;
-		
+
 		return i;
 	}
-	
+
 	/**
 	 * Decode value from the buffer using VByte.
 	 */
@@ -60,7 +60,7 @@ namespace csd
 		*value = 0;
 		int i = 0;
 		int shift = 0;
-		
+
 		while ( (&buffer[i]<=maxPtr) && !(buffer[i] & 0x80) )
 		{
 		   	if(shift>50) {
@@ -71,10 +71,10 @@ namespace csd
 			i++;
 			shift+=7;
 		}
-		
+
 		*value |= (size_t)(buffer[i] & 127) << shift;
 		i++;
-		
+
 		return i;
 	}
 
@@ -117,19 +117,17 @@ namespace csd
 	{
 	    uint64_t out = 0;
 	    int shift=0;
-	    uint64_t readbyte = in.get(); if(!in.good()) throw "Error reading input";
+	    uint64_t readbyte = in.get(); if(!in.good()) throw std::runtime_error("Error reading input");
 
 	    while( (readbyte & 0x80)==0) {
 	    	if(shift>50) {
-	    		throw "VByte.istream() Read too many bytes and still did not find a terminating byte";
+	    		throw std::runtime_error("VByte.istream() Read too many bytes and still did not find a terminating byte");
 	    	}
 		    out |= (readbyte & 127) << shift;
-		    readbyte = in.get(); if(!in.good()) throw "Error reading input";
+		    readbyte = in.get(); if(!in.good()) throw std::runtime_error("Error reading input");
 		    shift+=7;
 	    }
 	    out |= (readbyte & 127) << shift;
 	    return out;
 	}
 };
-
-

--- a/hdt-lib/src/rdf/RDFParser.cpp
+++ b/hdt-lib/src/rdf/RDFParser.cpp
@@ -9,6 +9,7 @@
 #ifdef HAVE_RAPTOR
 #include "RDFParserRaptorCallback.hpp"
 #endif
+#include "RDFParser.hpp"
 #include "RDFParserNtriples.hpp"
 #include "RDFParserNtriplesCallback.hpp"
 #ifdef HAVE_SERD
@@ -21,7 +22,7 @@ RDFParserPull *RDFParserPull::getParserPull(std::istream &stream, RDFNotation no
 	if(notation==NTRIPLES) {
 		return new RDFParserNtriples(stream,notation);
 	} else {
-		throw "No Parser available for input RDF Format";
+		throw ParseException("No Parser available for input RDF Format N-Triples");
 	}
 }
 
@@ -29,7 +30,7 @@ RDFParserPull *RDFParserPull::getParserPull(const char *fileName, RDFNotation no
 	if(notation==NTRIPLES) {
 		return new RDFParserNtriples(fileName,notation);
 	} else {
-		throw "No Parser available for input RDF Format";
+		throw ParseException("No Parser available for input RDF Format N-Triples");
 	}
 }
 
@@ -46,7 +47,7 @@ RDFParserCallback *RDFParserCallback::getParserCallback(RDFNotation notation) {
 #ifdef HAVE_RAPTOR
 		return new RDFParserRaptorCallback();
 #else
-		throw "No Parser available for input RDF Format";
+		throw ParseException("No Parser available for input RDF Format");
 #endif
 	}
 }

--- a/hdt-lib/src/rdf/RDFParserNtriples.cpp
+++ b/hdt-lib/src/rdf/RDFParserNtriples.cpp
@@ -151,7 +151,7 @@ TripleString *RDFParserNtriples::next() {
 
 	if (errorParsing == true || (pos != 0 && pos != 3)) {
 		cout << line << endl;
-		throw " :*********** FORMAT ERROR (NOT N3?) ***********";
+		throw std::runtime_error(" :*********** FORMAT ERROR (NOT N3?) ***********");
 	}
 
 	ts.setSubject(node[0]);

--- a/hdt-lib/src/rdf/RDFParserNtriplesCallback.cpp
+++ b/hdt-lib/src/rdf/RDFParserNtriplesCallback.cpp
@@ -6,9 +6,9 @@
  */
 
 #include "RDFParserNtriplesCallback.hpp"
+#include "RDFParser.hpp"
 #include "../util/fileUtil.hpp"
 #include "../util/unicode.hpp"
-
 #include <fstream>
 #include <stdexcept>
 #include <stdlib.h>
@@ -249,8 +249,8 @@ void RDFParserNtriplesCallback::doParse(const char *fileName, const char *baseUr
 		}
 
 		if (errorParsing == true || (pos != 0 && pos != 3)) {
-			cerr << endl << "Error parsing file at line " << numline << "|" << origLine << "|" << endl << endl;
-			//throw "Error parsing ntriples file.";
+			// cerr << endl << "Error parsing file at line " << numline << "|" << origLine << "|" << endl << endl;
+			throw ParseException(numline, "Error parsing file: |" + origLine + "|");
 		}
 
 		if(pos==3) {

--- a/hdt-lib/src/rdf/RDFParserRaptorCallback.cpp
+++ b/hdt-lib/src/rdf/RDFParserRaptorCallback.cpp
@@ -142,6 +142,8 @@ void RDFParserRaptorCallback::doParse(const char *fileName, const char *baseUri,
 	raptor_free_world(world);
 
 	if(error) {
+		//TODO: should probably remove this. Error is not set anywhere. Is this intended?
+		//And, if we keep this, make sure that error is an std:exception
 		throw error;
 	}
 }
@@ -149,4 +151,4 @@ void RDFParserRaptorCallback::doParse(const char *fileName, const char *baseUri,
 }
 #else
 int RaptorParserSupportDummySymbol;
-#endif 
+#endif

--- a/hdt-lib/src/rdf/RDFParserSerd.cpp
+++ b/hdt-lib/src/rdf/RDFParserSerd.cpp
@@ -4,7 +4,7 @@
 
 #include "../util/fileUtil.hpp"
 #include "RDFParserSerd.hpp"
-
+#include "RDFParser.hpp"
 
 namespace hdt {
 
@@ -133,7 +133,7 @@ const SerdSyntax RDFParserSerd::getParserType(RDFNotation notation){
     case TURTLE:
         return SERD_TURTLE;
     default:
-        throw "Serd parser only supports ntriples and turtle.";
+        throw ParseException("Serd parser only supports ntriples and turtle.");
     }
 }
 
@@ -161,7 +161,7 @@ void RDFParserSerd::doParse(const char *fileName, const char *baseUri, RDFNotati
     FILE *in_fd = fopen((const char*)input, "r");
     // TODO: fadvise sequential
     if(in_fd==NULL) {
-        throw "Could not open input file for parsing";
+        throw ParseException("Could not open input file for parsing");
     }
     SerdStatus status = serd_reader_read_file_handle(reader, in_fd, (const uint8_t *)fileName);
 

--- a/hdt-lib/src/rdf/RDFSerializer.cpp
+++ b/hdt-lib/src/rdf/RDFSerializer.cpp
@@ -21,7 +21,7 @@ RDFSerializer *RDFSerializer::getSerializer(std::ostream &out, RDFNotation notat
 	if(notation==NTRIPLES) {
 		return new RDFSerializerNTriples(out,notation);
 	} else {
-		throw "RDFSerialization not available";
+		throw std::runtime_error("RDFSerialization not available");
 	}
 #endif
 }
@@ -34,7 +34,7 @@ RDFSerializer *RDFSerializer::getSerializer(const char *fileName, RDFNotation no
 	if(notation==NTRIPLES) {
 		return new RDFSerializerNTriples(fileName,notation);
 	} else {
-		throw "RDFSerialization not available";
+		throw std::runtime_error("RDFSerialization not available");
 	}
 #endif
 }

--- a/hdt-lib/src/rdf/RDFSerializerNTriples.cpp
+++ b/hdt-lib/src/rdf/RDFSerializerNTriples.cpp
@@ -31,7 +31,7 @@ RDFSerializerNTriples::~RDFSerializerNTriples() {
 
 void serializeTerm(std::string str, ostream &output) {
 	if(str=="") {
-		throw "Empty Value on triple!";
+		throw std::runtime_error("Empty Value on triple!");
 	}
 
 	// FIXME: Escape non-ascii.

--- a/hdt-lib/src/rdf/RDFSerializerRaptor.cpp
+++ b/hdt-lib/src/rdf/RDFSerializerRaptor.cpp
@@ -96,7 +96,7 @@ RDFSerializerRaptor::~RDFSerializerRaptor() {
 raptor_term *getTerm(string &str, raptor_world *world) {
 
 	if(str=="") {
-		throw "Empty Value on triple!";
+		throw std::runtime_error("Empty Value on triple!");
 	}
 
 	if(str.at(0)=='"') {

--- a/hdt-lib/src/sequence/AdjacencyList.cpp
+++ b/hdt-lib/src/sequence/AdjacencyList.cpp
@@ -150,7 +150,7 @@ size_t AdjacencyList::binSearch(unsigned int element, size_t begin, size_t end) 
 		else
 			return mid;
 	}
-	throw "Not found";
+	throw std::runtime_error("Not found");
 }
 
 size_t AdjacencyList::linSearch(unsigned int element, size_t begin, size_t end) {

--- a/hdt-lib/src/sequence/HuffmanSequence.cpp
+++ b/hdt-lib/src/sequence/HuffmanSequence.cpp
@@ -103,7 +103,7 @@ size_t HuffmanSequence::load(const unsigned char *ptr, const unsigned char *ptrM
 void HuffmanSequence::save(std::ostream & output)
 {
 	if(huffman==NULL) {
-		throw "Must add elements to stream before saving";
+		throw std::runtime_error("Must add elements to stream before saving");
 	}
 
 	// Create encoded vector

--- a/hdt-lib/src/sequence/LogSequence.cpp
+++ b/hdt-lib/src/sequence/LogSequence.cpp
@@ -67,7 +67,7 @@ void LogSequence::add(IteratorUInt &elements)
 	while(elements.hasNext()) {
 		size_t element = elements.next();
 		if(element>((size_t)-1)) {
-			throw "Error, saving a value out of range";
+			throw std::out_of_range("Error, saving a value out of range");
 		}
 		vector.push_back((unsigned int)element);
 		max = element > max ? element : max;

--- a/hdt-lib/src/sequence/LogSequence2.cpp
+++ b/hdt-lib/src/sequence/LogSequence2.cpp
@@ -83,7 +83,7 @@ LogSequence2::~LogSequence2() {
 size_t LogSequence2::get(size_t position)
 {
 	if(position>=numentries) {
-		throw "Trying to get an element bigger than the array.";
+		throw std::runtime_error("Trying to get an element bigger than the array.");
 	}
 
 	return get_field(&array[0], numbits, position);
@@ -92,7 +92,7 @@ size_t LogSequence2::get(size_t position)
 void LogSequence2::add(IteratorUInt &elements)
 {
 	if(IsMapped) {
-		throw "Data structure read-only when mapped.";
+		throw std::runtime_error("Data structure read-only when mapped.");
 	}
 
 	size_t max = 0;
@@ -125,20 +125,20 @@ void LogSequence2::add(IteratorUInt &elements)
 
 void LogSequence2::set(size_t position, size_t value) {
 	if(IsMapped) {
-		throw "Data structure read-only when mapped.";
+		throw std::runtime_error("Data structure read-only when mapped.");
 	}
 	if(position>numentries) {
-		throw "Trying to modify a position out of the structure capacity. Use push_back() instead";
+		throw std::runtime_error("Trying to modify a position out of the structure capacity. Use push_back() instead");
 	}
 	if(value>maxval) {
-		throw "Trying to insert a value bigger that expected. Please increase numbits when creating the data structure.";
+		throw std::runtime_error("Trying to insert a value bigger that expected. Please increase numbits when creating the data structure.");
 	}
     set_field(array, numbits, position, value);
 }
 
 void LogSequence2::push_back(size_t value) {
 	if(IsMapped) {
-		throw "Data structure read-only when mapped.";
+		throw std::runtime_error("Data structure read-only when mapped.");
 	}
 	size_t neededSize = numElementsFor(numbits, numentries+1);
 	if(data.size()<neededSize) {
@@ -147,7 +147,7 @@ void LogSequence2::push_back(size_t value) {
         array = &data[0];
 	}
 	if(value>maxval) {
-		throw "Trying to insert a value bigger that expected. Please increase numbits when creating the data structure.";
+		throw std::runtime_error("Trying to insert a value bigger that expected. Please increase numbits when creating the data structure.");
 	}
 	set(numentries, value);
 	numentries++;
@@ -155,7 +155,7 @@ void LogSequence2::push_back(size_t value) {
 
 void LogSequence2::resize(size_t newNumEntries) {
 	if(IsMapped) {
-		throw "Data structure read-only when mapped.";
+		throw std::runtime_error("Data structure read-only when mapped.");
 	}
 	size_t neededSize = numElementsFor(numbits, newNumEntries);
 	if(data.size()<neededSize) {
@@ -200,7 +200,7 @@ void LogSequence2::load(std::istream & input)
 	uint8_t type;
 	crch.readData(input, (unsigned char*)&type, sizeof(type));
 	if(type!=TYPE_SEQLOG) {
-		//throw "Trying to read a LOGArray but data is not LogArray";
+		//throw std::runtime_error("Trying to read a LOGArray but data is not LogArray");
 	}
 
 	// Read numbits
@@ -214,14 +214,14 @@ void LogSequence2::load(std::istream & input)
 	// Validate Checksum Header
 	crc8_t filecrch = crc8_read(input);
 	if(crch.getValue()!=filecrch) {
-		throw "Checksum error while reading LogSequence2 header.";
+		throw std::runtime_error("Checksum error while reading LogSequence2 header.");
 	}
 
 	// Update local variables and validate
 	maxval = maxVal(numbits);
 	numentries = (size_t) numentries64;
 	if(numbits>sizeof(size_t)*8 || numentries64>std::numeric_limits<size_t>::max()) {
-		throw "This data structure is too big for this machine";
+		throw std::out_of_range("This data structure is too big for this machine");
 	}
 
 	// Calculate data size, reserve buffer.
@@ -236,13 +236,13 @@ void LogSequence2::load(std::istream & input)
 	// Validate checksum data
 	crc32_t filecrcd = crc32_read(input);
 	if(crcd.getValue()!=filecrcd) {
-		throw "Checksum error while reading LogSequence2 Data";
+		throw std::runtime_error("Checksum error while reading LogSequence2 Data");
 	}
 
 	IsMapped = false;
 }
 
-#define CHECKPTR(base, max, size) if(((base)+(size))>(max)) throw "Could not read completely the HDT from the file.";
+#define CHECKPTR(base, max, size) if(((base)+(size))>(max)) throw std::runtime_error("Could not read completely the HDT from the file.");
 
 size_t LogSequence2::load(const unsigned char *ptr, const unsigned char *ptrMax, ProgressListener *listener) {
 	size_t count = 0;
@@ -250,7 +250,7 @@ size_t LogSequence2::load(const unsigned char *ptr, const unsigned char *ptrMax,
 	// Read type
 	CHECKPTR(&ptr[count], ptrMax, 1);
 	if(ptr[count]!=TYPE_SEQLOG) {
-		throw "Trying to read a LOGArray but data is not LogArray";
+		throw std::runtime_error("Trying to read a LOGArray but data is not LogArray");
 	}
 	count++;
 
@@ -267,13 +267,13 @@ size_t LogSequence2::load(const unsigned char *ptr, const unsigned char *ptrMax,
     crch.update(&ptr[0], count);
     CHECKPTR(&ptr[count], ptrMax, 1);
     if(crch.getValue()!=ptr[count++])
-        throw "Checksum error while reading LogSequence2 header.";
+        throw std::runtime_error("Checksum error while reading LogSequence2 header.");
 
     // Update local variables and validate
     maxval = maxVal(numbits);
     numentries = (size_t) numentries64;
     if(numbits>sizeof(size_t)*8 || numentries64>std::numeric_limits<size_t>::max()) {
-        throw "This data structure is too big for this machine";
+        throw std::runtime_error("This data structure is too big for this machine");
     }
 
     // Setup array of data
@@ -283,7 +283,7 @@ size_t LogSequence2::load(const unsigned char *ptr, const unsigned char *ptrMax,
     IsMapped = true;
 
     if(&ptr[count]>=ptrMax)
-        throw "LogSequence2 tries to read beyond the end of the file";
+        throw std::runtime_error("LogSequence2 tries to read beyond the end of the file");
 
     CHECKPTR(&ptr[count], ptrMax, 4);
     count+=4; // CRC of data

--- a/hdt-lib/src/sequence/WaveletSequence.cpp
+++ b/hdt-lib/src/sequence/WaveletSequence.cpp
@@ -81,7 +81,7 @@ void WaveletSequence::add(IteratorUInt &elements)
 		size_t element = elements.next();
 
 		if(element>((size_t)-1)) {
-			throw "Trying to insert a value bigger than the permitted for the architecture";
+			throw std::runtime_error("Trying to insert a value bigger than the permitted for the architecture");
 		}
 
 		vector.push_back(element);

--- a/hdt-lib/src/sparql/BaseJoinBinding.hpp
+++ b/hdt-lib/src/sparql/BaseJoinBinding.hpp
@@ -83,7 +83,7 @@ public:
 
 	unsigned int getVarValue(unsigned int numvar) {
 		if(numvar>vars.size()) {
-			throw "Accessing out of bound variable";
+			throw std::out_of_range("Accessing out of bound variable");
 		}
 		if(!varOperand[numvar]) {
 			// Left operand
@@ -95,7 +95,7 @@ public:
 	}
 	const char *getVarName(unsigned int numvar) {
 		if(numvar>vars.size()){
-			throw "Variable not available";
+			throw std::runtime_error("Variable not available");
 		}
 		return varnames[numvar].c_str();
 	}

--- a/hdt-lib/src/sparql/CachedBinding.hpp
+++ b/hdt-lib/src/sparql/CachedBinding.hpp
@@ -90,7 +90,7 @@ public:
 		return varnames[numvar].c_str();
 	}
 	void searchVar(unsigned int numvar, unsigned int value) {
-		throw "Unsupported";
+		throw std::logic_error("Unsupported");
 	}
 
 	void goToStart() {

--- a/hdt-lib/src/sparql/IndexJoinBinding.cpp
+++ b/hdt-lib/src/sparql/IndexJoinBinding.cpp
@@ -35,7 +35,7 @@ ResultEstimationType IndexJoinBinding::estimationAccuracy() {
 }
 
 bool IndexJoinBinding::findNext(const char *varName, unsigned int value) {
-	throw "Unsupported";
+	throw std::logic_error("Unsupported");
 }
 
 bool IndexJoinBinding::findNext() {
@@ -74,7 +74,7 @@ void IndexJoinBinding::goToStart() {
 }
 
 void IndexJoinBinding::searchVar(unsigned int numvar, unsigned int value) {
-	throw "Unsupported";
+	throw std::logic_error("Unsupported");
 }
 
 

--- a/hdt-lib/src/sparql/MergeJoinBinding.cpp
+++ b/hdt-lib/src/sparql/MergeJoinBinding.cpp
@@ -18,7 +18,7 @@ MergeJoinBinding::MergeJoinBinding(char *var, VarBindingInterface *left, VarBind
     goToStart();
 
     if(!left->isOrdered(left->getVarIndex(var))||!right->isOrdered(right->getVarIndex(var))) {
-	throw "Cannot merge join if the variables are not sorted!";
+	throw std::runtime_error("Cannot merge join if the variables are not sorted!");
     }
 
     cerr << "Merge join of " << left->estimatedNumResults() << " against " << right->estimatedNumResults() << endl;
@@ -44,7 +44,7 @@ ResultEstimationType MergeJoinBinding::estimationAccuracy() {
 }
 
 bool MergeJoinBinding::findNext(const char *varName, unsigned int value) {
-    throw "Unsupported";
+    throw std::logic_error("Unsupported");
 }
 
 bool MergeJoinBinding::findNext() {
@@ -161,7 +161,7 @@ void MergeJoinBinding::goToStart() {
 
 unsigned int MergeJoinBinding::getVarValue(unsigned int numvar) {
     if(numvar>=getNumVars()) {
-	throw "Accessing out of bound variable";
+	throw std::out_of_range("Accessing out of bound variable");
     }
 
     if(!varOperand[numvar]) {
@@ -180,7 +180,7 @@ unsigned int MergeJoinBinding::getVarValue(unsigned int numvar) {
 }
 
 void MergeJoinBinding::searchVar(unsigned int numvar, unsigned int value) {
-    throw "Unsupported";
+    throw std::logic_error("Unsupported");
 }
 
 }

--- a/hdt-lib/src/sparql/QueryProcessor.cpp
+++ b/hdt-lib/src/sparql/QueryProcessor.cpp
@@ -45,7 +45,7 @@ set<string> getCommonVars(VarBindingInterface& a, VarBindingInterface& b) {
 
 
 VarBindingString* QueryProcessor::searchJoin(vector<TripleString>& patterns, set<string>& vars) {
-	try {
+	// try {
 		if (patterns.size() == 0) {
 			return new EmptyVarBingingString();
 		}
@@ -163,12 +163,12 @@ VarBindingString* QueryProcessor::searchJoin(vector<TripleString>& patterns, set
 		}
 
 		return new BasicVarBindingString(varRole, new VarFilterBinding(root, vars), hdt->getDictionary());
-	} catch (char *e) {
-		cout << "Exception: " << e << endl;
-		throw "Exception";
-	}
+	// } catch (char *e) {
+	// 	cout << "Exception: " << e << endl;
+	// 	throw std::runtime_error("Exception");
+	// }
 
-	throw "Could not find query tree";
+	throw std::runtime_error("Could not find query tree");
 }
 
 }

--- a/hdt-lib/src/sparql/QueryProcessor.hpp
+++ b/hdt-lib/src/sparql/QueryProcessor.hpp
@@ -37,7 +37,7 @@ private:
 			}
 		}
 		cout << "Var name: " << varName << " not found" << endl;
-		throw "Var name does not exist";
+		throw std::runtime_error("Var name does not exist");
 	}
 public:
 	BasicVarBindingString(map<string, TripleComponentRole> &varRole, VarBindingID *varID, Dictionary *dict) :

--- a/hdt-lib/src/sparql/SortBinding.cpp
+++ b/hdt-lib/src/sparql/SortBinding.cpp
@@ -54,23 +54,23 @@ SortBinding::~SortBinding(){
 }
 
 unsigned int SortBinding::isOrdered(unsigned int numvar) {
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 unsigned int SortBinding::estimatedNumResults() {
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 ResultEstimationType SortBinding::estimationAccuracy() {
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 bool SortBinding::findNext(const char *varName, unsigned int value) {
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 bool SortBinding::findNext() {
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 //virtual void findNext(unsigned int numvar, unsigned int value=0);
@@ -79,7 +79,7 @@ void SortBinding::goToStart() {
 }
 
 unsigned int SortBinding::getVarValue(unsigned int numvar) {
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 void SortBinding::searchVar(unsigned int numvar, unsigned int value){

--- a/hdt-lib/src/sparql/TriplePatternBinding.cpp
+++ b/hdt-lib/src/sparql/TriplePatternBinding.cpp
@@ -41,7 +41,7 @@ unsigned int TriplePatternBinding::isOrdered(unsigned int numvar) {
     case 3:
 	return iterator->isSorted(OBJECT);
     }
-    throw "Wrong numvar";
+    throw std::runtime_error("Wrong numvar");
 }
 
 unsigned int TriplePatternBinding::estimatedNumResults() {
@@ -71,7 +71,7 @@ bool TriplePatternBinding::findNext(const char *varName, unsigned int value=0) {
 		currentTriple = iterator->next();
 
 		if(getVar(varName)!=value) {
-			throw "Found value is not what we were searching!";
+			throw std::runtime_error("Found value is not what we were searching!");
 		}
 		return true;
 	}
@@ -89,7 +89,7 @@ unsigned int TriplePatternBinding::getNumVars() {
 }
 unsigned int TriplePatternBinding::getVarValue(unsigned int numvar) {
 	if(numvar>vars.size()){
-		throw "Variable not available";
+		throw std::runtime_error("Variable not available");
 	}
 	switch(vars[numvar]) {
 	case 1:
@@ -99,7 +99,7 @@ unsigned int TriplePatternBinding::getVarValue(unsigned int numvar) {
 	case 3:
 		return currentTriple->getObject();
 	default:
-		throw "Wrong numvar";
+		throw std::runtime_error("Wrong numvar");
 	}
 }
 unsigned int TriplePatternBinding::getVarValue(const char *varname) {
@@ -108,7 +108,7 @@ unsigned int TriplePatternBinding::getVarValue(const char *varname) {
 
 const char *TriplePatternBinding::getVarName(unsigned int numvar) {
 	if(numvar>vars.size()){
-		throw "Variable not available";
+		throw std::runtime_error("Variable not available");
 	}
 	return varnames[numvar].c_str();
 }

--- a/hdt-lib/src/sparql/VarBindingInterface.hpp
+++ b/hdt-lib/src/sparql/VarBindingInterface.hpp
@@ -51,7 +51,7 @@ public:
 			}
 		}
 		cout << "Var name: " << varName << " not found" << endl;
-		throw "Var name does not exist";
+		throw std::runtime_error("Var name does not exist");
 	}
 	virtual const char *getVarName(unsigned int numvar)=0;
 	virtual void searchVar(unsigned int numvar, unsigned int value)=0;

--- a/hdt-lib/src/sparql/VarFilterBinding.hpp
+++ b/hdt-lib/src/sparql/VarFilterBinding.hpp
@@ -58,14 +58,14 @@ public:
 
     unsigned int getVarValue(unsigned int numvar) {
 	if(numvar>varIds.size()) {
-	    throw "No such variable";
+	    throw std::runtime_error("No such variable");
 	}
 	return child->getVarValue(varIds[numvar]);
     }
 
     const char *getVarName(unsigned int numvar) {
 	if(numvar>varIds.size()) {
-	    throw "No such variable";
+	    throw std::runtime_error("No such variable");
 	}
 	return varNames[numvar].c_str();
     }
@@ -82,4 +82,3 @@ public:
 }
 
 #endif // VARFILTERBINDING_HPP
-

--- a/hdt-lib/src/triples/BitmapTriples.cpp
+++ b/hdt-lib/src/triples/BitmapTriples.cpp
@@ -41,7 +41,7 @@
 
 namespace hdt {
 
-#define CHECK_BITMAPTRIPLES_INITIALIZED if(bitmapY==NULL || bitmapZ==NULL){	throw "Accessing uninitialized BitmapTriples"; }
+#define CHECK_BITMAPTRIPLES_INITIALIZED if(bitmapY==NULL || bitmapZ==NULL){	throw std::runtime_error("Accessing uninitialized BitmapTriples"); }
 
 BitmapTriples::BitmapTriples() : order(SPO) {
 	string typey="";
@@ -49,7 +49,7 @@ BitmapTriples::BitmapTriples() : order(SPO) {
 	try{
 		typey = spec.get("stream.y");
 		typez = spec.get("stream.z");
-	}catch (exception& e){}
+	}catch (std::exception& e){}
 	arrayY = IntSequence::getArray(typey);
 	arrayZ = IntSequence::getArray(typez);
 	arrayIndex = NULL;
@@ -64,7 +64,7 @@ BitmapTriples::BitmapTriples(HDTSpecification &specification) : spec(specificati
 	std::string orderStr = "";
 	try{
 		orderStr = spec.get("triplesOrder");
-	}catch (exception& e){}
+	}catch (std::exception& e){}
 
 	order= parseOrder(orderStr.c_str());
 	if(order==Unknown)
@@ -74,7 +74,7 @@ BitmapTriples::BitmapTriples(HDTSpecification &specification) : spec(specificati
 	try{
 		typey = spec.get("stream.y");
 		typez = spec.get("stream.z");
-	}catch (exception& e){}
+	}catch (std::exception& e){}
 	arrayY = IntSequence::getArray(typey);
 	arrayZ = IntSequence::getArray(typez);
 	arrayIndex = NULL;
@@ -149,7 +149,7 @@ void BitmapTriples::load(ModifiableTriples &triples, ProgressListener *listener)
 			vectorZ->push_back(z);
 		} else if(x!=lastX) {
             if(x!=lastX+1) {
-                throw "Error: The subjects must be correlative.";
+                throw std::runtime_error("Error: The subjects must be correlative.");
             }
 			bitmapY->append(true);
 			vectorY->push_back(y);
@@ -158,7 +158,7 @@ void BitmapTriples::load(ModifiableTriples &triples, ProgressListener *listener)
 			vectorZ->push_back(z);
 		} else if(y!=lastY) {
             if(y<lastY) {
-                throw "Error: The predicates must be in increasing order.";
+                throw std::runtime_error("Error: The predicates must be in increasing order.");
             }
             bitmapY->append(false);
 			vectorY->push_back(y);
@@ -167,7 +167,7 @@ void BitmapTriples::load(ModifiableTriples &triples, ProgressListener *listener)
 			vectorZ->push_back(z);
 		} else {
             if(z<=lastZ) {
-                throw "Error, The objects must be in increasing order.";
+                throw std::runtime_error("Error, The objects must be in increasing order.");
             }
             bitmapZ->append(false);
 			vectorZ->push_back(z);
@@ -518,7 +518,7 @@ void BitmapTriples::generateIndexFast(ProgressListener *listener) {
 	for(unsigned int i=0;i<index.size();i++){
 		if(index[i].size()<=0) {
 			cerr << "Error, object "<< i << " never appears" << endl;
-			throw "Error generating index: Object should appear at least once";
+			throw std::runtime_error("Error generating index: Object should appear at least once");
 		}
 
 		// Sort by predicate of this object
@@ -669,7 +669,7 @@ void BitmapTriples::load(std::istream &input, ControlInformation &controlInforma
 {
 	std::string format = controlInformation.getFormat();
 	if(format!=getType()) {
-		throw "Trying to read a BitmapTriples but the data is not BitmapTriples";
+		throw std::runtime_error("Trying to read a BitmapTriples but the data is not BitmapTriples");
 	}
 
 	order = (TripleComponentOrder) controlInformation.getUint("order");
@@ -680,14 +680,14 @@ void BitmapTriples::load(std::istream &input, ControlInformation &controlInforma
 	iListener.notifyProgress(0, "BitmapTriples loading Bitmap Y");
 	bitmapY = BitSequence375::load(input);
 	if(bitmapY==NULL){
-		throw "Could not read bitmapY.";
+		throw std::runtime_error("Could not read bitmapY.");
 	}
 
 	iListener.setRange(5,10);
 	iListener.notifyProgress(0, "BitmapTriples loading Bitmap Z");
 	bitmapZ = BitSequence375::load(input);
 	if(bitmapZ==NULL){
-		throw "Could not read bitmapZ.";
+		throw std::runtime_error("Could not read bitmapZ.");
 	}
 
 	iListener.setRange(10,20);
@@ -712,7 +712,7 @@ size_t BitmapTriples::load(unsigned char *ptr, unsigned char *ptrMax, ProgressLi
 
 	std::string format = controlInformation.getFormat();
 	if(format!=getType()) {
-		throw "Trying to read a FourSectionDictionary but the data is not FourSectionDictionary";
+		throw std::runtime_error("Trying to read a FourSectionDictionary but the data is not FourSectionDictionary");
 	}
 
     order = (TripleComponentOrder) controlInformation.getUint("order");
@@ -788,20 +788,20 @@ void BitmapTriples::loadIndex(std::istream &input, ControlInformation &controlIn
     size_t numTriples = controlInformation.getUint("numTriples");
 
 	if(controlInformation.getType()!=INDEX) {
-		throw "Trying to read Index but data is not index.";
+		throw std::runtime_error("Trying to read Index but data is not index.");
 	}
 
 	if(controlInformation.getFormat()!=HDTVocabulary::INDEX_TYPE_FOQ) {
-		throw "Error reading index. Please delete .hdt.index and let application generate it again.";
+		throw std::runtime_error("Error reading index. Please delete .hdt.index and let application generate it again.");
 	}
 
 	if(this->getNumberOfElements()!=numTriples) {
 		// FIXME: Force index regeneration instead of error.
-		throw "The supplied index does not have the same number of triples as the dataset";
+		throw std::runtime_error("The supplied index does not have the same number of triples as the dataset");
 	}
 
 	if(this->getOrder()!=controlInformation.getUint("order")) {
-		throw "The order of the triples is different than the index.";
+		throw std::runtime_error("The order of the triples is different than the index.");
 	}
 
 	IntermediateListener iListener(listener);
@@ -848,7 +848,7 @@ size_t BitmapTriples::loadIndex(unsigned char *ptr, unsigned char *ptrMax, Progr
     count += controlInformation.load(&ptr[count], ptrMax);
 
     if(controlInformation.getType()!=INDEX) {
-        throw "Trying to load an HDT Index, but the ControlInformation states that it's not an index.";
+        throw std::runtime_error("Trying to load an HDT Index, but the ControlInformation states that it's not an index.");
     }
 
     size_t numTriples = controlInformation.getUint("numTriples");
@@ -860,7 +860,7 @@ size_t BitmapTriples::loadIndex(unsigned char *ptr, unsigned char *ptrMax, Progr
 
     if(this->getNumberOfElements()!=numTriples) {
     	// FIXME: Force index regeneration instead of error.
-        throw "The supplied index does not have the same number of triples as the dataset";
+        throw std::runtime_error("The supplied index does not have the same number of triples as the dataset");
     }
 
     // Load Bitmap

--- a/hdt-lib/src/triples/BitmapTriplesIterators.cpp
+++ b/hdt-lib/src/triples/BitmapTriplesIterators.cpp
@@ -106,7 +106,7 @@ void BitmapTriplesSearchIterator::findRange()
                     maxZ = adjZ.last(minY)+1;
                     //maxZ = adjZ.findNext(minZ);
                 }
-            } catch (const char *ex) {
+            } catch (std::exception& e) {
                 // Item not found in list, no results.
                 minY = minZ = maxY = maxZ = 0;
             }
@@ -249,7 +249,7 @@ bool BitmapTriplesSearchIterator::canGoTo() {
 
 void BitmapTriplesSearchIterator::goTo(unsigned int pos) {
 	if ((posZ + pos) >= maxZ) {
-			throw "Cannot goTo on this pattern.";
+			throw std::runtime_error("Cannot goTo on this pattern.");
 	}
 	posZ += pos; // move the position of Z
 	goToY(); // go to the correct Y
@@ -303,7 +303,7 @@ bool BitmapTriplesSearchIterator::isSorted(TripleComponentRole role) {
     }
 
 
-    throw "Order not supported";
+    throw std::runtime_error("Order not supported");
 }
 
 
@@ -323,7 +323,7 @@ MiddleWaveletIterator::MiddleWaveletIterator(BitmapTriples *trip, TripleID &pat)
     patZ = pattern.getObject();
 
     if(patY==0) {
-        throw "This iterator is not suitable for this pattern";
+        throw std::runtime_error("This iterator is not suitable for this pattern");
     }
 
 #if 0
@@ -475,12 +475,12 @@ bool MiddleWaveletIterator::findNextOccurrence(unsigned int value, unsigned char
                 y = adjY.get(posY);
                 x = adjY.findListIndex(posY)+1;
                 return true;
-            } catch (const char *ex) {
+            } catch (std::exception& e) {
                 // Not found
             }
         }
     }
-    throw "Cannot search component";
+    throw std::runtime_error("Cannot search component");
 }
 
 bool MiddleWaveletIterator::isSorted(TripleComponentRole role) {
@@ -502,7 +502,7 @@ bool MiddleWaveletIterator::isSorted(TripleComponentRole role) {
 	}
     }
 
-    throw "Order not supported";
+    throw std::runtime_error("Order not supported");
 }
 
 
@@ -524,7 +524,7 @@ IteratorY::IteratorY(BitmapTriples *trip, TripleID &pat) :
     patZ = pattern.getObject();
 
     if(patY==0) {
-        throw "This iterator is not suitable for this pattern";
+        throw std::runtime_error("This iterator is not suitable for this pattern");
     }
 
 #if 0
@@ -630,11 +630,11 @@ TripleComponentOrder IteratorY::getOrder() {
 }
 
 bool IteratorY::findNextOccurrence(unsigned int value, unsigned char component) {
-    throw "Not implemented";
+    throw std::logic_error("Not Implemented");
 }
 
 bool IteratorY::isSorted(TripleComponentRole role) {
-    throw "Not implemented";
+    throw std::logic_error("Not Implemented");
 }
 
 
@@ -657,7 +657,7 @@ ObjectIndexIterator::ObjectIndexIterator(BitmapTriples *trip, TripleID &pat) :
     patZ = pattern.getObject();
 
     if(patZ==0) {
-    	throw "This iterator is not suitable for this pattern";
+    	throw std::runtime_error("This iterator is not suitable for this pattern");
     }
 
 #if 0
@@ -682,7 +682,7 @@ unsigned int ObjectIndexIterator::getPosZ(unsigned int indexObjectPos) {
     try {
         posZ = adjZ.find(posAdjList, patZ);
 //        z = adjZ.get(posZ);
-    } catch (const char *ex) {
+    } catch (std::exception& e) {
 	cerr << "posZ not found in Index!!!!" << endl;
         posZ = adjZ.find(posAdjList);
     }
@@ -769,7 +769,7 @@ void ObjectIndexIterator::calculateRange() {
         while (minIndex <= maxIndex) {
             //cout << "binSearch range: " << minIndex << ", " << maxIndex << endl;
             int mid = (minIndex + maxIndex) / 2;
-            unsigned int predicate=getY(mid);        
+            unsigned int predicate=getY(mid);
 
             if (patY > predicate) {
                 minIndex = mid + 1;
@@ -882,7 +882,7 @@ bool ObjectIndexIterator::canGoTo()
 void ObjectIndexIterator::goTo(unsigned int pos)
 {
     if(minIndex+pos>maxIndex) {
-	throw "Cannot goto beyond last element";
+	throw std::runtime_error("Cannot goto beyond last element");
     }
     posIndex = minIndex+pos;
 }
@@ -932,7 +932,7 @@ bool ObjectIndexIterator::isSorted(TripleComponentRole role) {
 	}
     }
 
-    throw "Order not supported";
+    throw std::runtime_error("Order not supported");
 }
 
 

--- a/hdt-lib/src/triples/CompactTriples.cpp
+++ b/hdt-lib/src/triples/CompactTriples.cpp
@@ -43,7 +43,7 @@ CompactTriples::CompactTriples() : numTriples(0), order(SPO) {
 	try{
 		typey = spec.get("stream.y");
 		typez = spec.get("stream.z");
-	}catch (exception& e){}
+	}catch (std::exception& e){}
 	streamY = IntSequence::getArray(typey);
 	streamZ = IntSequence::getArray(typez);
 }
@@ -61,7 +61,7 @@ CompactTriples::CompactTriples(HDTSpecification &specification) : spec(specifica
 	try{
 		typey = spec.get("stream.y");
 		typez = spec.get("stream.z");
-	}catch (exception& e){}
+	}catch (std::exception& e){}
 	streamY = IntSequence::getArray(typey);
 	streamZ = IntSequence::getArray(typez);
 }
@@ -178,7 +178,7 @@ IteratorTripleID *CompactTriples::search(TripleID & pattern)
 }
 
 IteratorTripleID *CompactTriples::searchJoin(TripleID &a, TripleID &b, unsigned short conditions) {
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 void CompactTriples::save(std::ostream & output, ControlInformation &controlInformation, ProgressListener *listener)
@@ -204,7 +204,7 @@ void CompactTriples::load(std::istream &input, ControlInformation &controlInform
 {
 	std::string format = controlInformation.getFormat();
 	if(format != HDTVocabulary::TRIPLES_TYPE_COMPACT) {
-		throw "Trying to read CompactTriples but data is not CompactTriples";
+		throw std::runtime_error("Trying to read CompactTriples but data is not CompactTriples");
 	}
 
 	numTriples = controlInformation.getUint("numTriples");
@@ -227,7 +227,7 @@ void CompactTriples::load(std::istream &input, ControlInformation &controlInform
 
 size_t CompactTriples::load(unsigned char *ptr, unsigned char *ptrMax, ProgressListener *listener)
 {
-    throw "Not implemented";
+    throw std::logic_error("Not Implemented");
 }
 
 void CompactTriples::generateIndex(ProgressListener *listener) {

--- a/hdt-lib/src/triples/PlainTriples.cpp
+++ b/hdt-lib/src/triples/PlainTriples.cpp
@@ -44,7 +44,7 @@ PlainTriples::PlainTriples() : order(SPO) {
 		typex = spec.get("stream.x");
 		typey = spec.get("stream.y");
 		typez = spec.get("stream.z");
-	}catch (exception& e){}
+	}catch (std::exception& e){}
 	streamX = IntSequence::getArray(typex);
 	streamY = IntSequence::getArray(typey);
 	streamZ = IntSequence::getArray(typez);
@@ -66,7 +66,7 @@ PlainTriples::PlainTriples(HDTSpecification &specification) : spec(specification
 		typex = spec.get("stream.x");
 		typey = spec.get("stream.y");
 		typez = spec.get("stream.z");
-	}catch (exception& e){}
+	}catch (std::exception& e){}
 	streamX = IntSequence::getArray(typex);
 	streamY = IntSequence::getArray(typey);
 	streamZ = IntSequence::getArray(typez);
@@ -129,7 +129,7 @@ IteratorTripleID *PlainTriples::search(TripleID & pattern)
 }
 
 IteratorTripleID *PlainTriples::searchJoin(TripleID &a, TripleID &b, unsigned short conditions) {
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 void PlainTriples::save(std::ostream & output, ControlInformation &controlInformation, ProgressListener *listener)
@@ -159,7 +159,7 @@ void PlainTriples::load(std::istream &input, ControlInformation &controlInformat
 {
 	std::string format = controlInformation.getFormat();
 	if(format!=getType()) {
-		throw "Trying to read PlainTriples but the data is not PlainTriples";
+		throw std::runtime_error("Trying to read PlainTriples but the data is not PlainTriples");
 	}
 
 	//unsigned int numTriples = controlInformation.getUint("numTriples");
@@ -188,7 +188,7 @@ void PlainTriples::load(std::istream &input, ControlInformation &controlInformat
 
 size_t PlainTriples::load(unsigned char *ptr, unsigned char *ptrMax, ProgressListener *listener)
 {
-    throw "Not implemented";
+    throw std::logic_error("Not Implemented");
 }
 
 void PlainTriples::generateIndex(ProgressListener *listener) {
@@ -301,6 +301,3 @@ void ComponentIterator::goToStart()
 }
 
 }
-
-
-

--- a/hdt-lib/src/triples/TripleListDisk.cpp
+++ b/hdt-lib/src/triples/TripleListDisk.cpp
@@ -70,7 +70,7 @@ TripleListDisk::TripleListDisk() :
 
 	if (fd == -1) {
 		perror("Error open");
-		throw "Error open";
+		throw std::runtime_error("Error open");
 	}
 
 	fileName.assign( &v[0] );
@@ -105,7 +105,7 @@ void TripleListDisk::mapFile() {
 	arrayTriples = (TripleID *) mmap(0, mappedSize, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
 #endif
 	if(arrayTriples==(TripleID *)-1) {
-		throw "Could not mmap";
+		throw std::runtime_error("Could not mmap");
 	}
 }
 
@@ -126,7 +126,7 @@ void TripleListDisk::getFileSize() {
 	int ret = fstat(fd, &st);
 	if(ret==-1) {
 		perror("Error fstat");
-		throw "Error fstat";
+		throw std::runtime_error("Error fstat");
 	}
 	mappedSize = st.st_size;
 }
@@ -145,14 +145,14 @@ void TripleListDisk::ensureSize(unsigned int newsize) {
 	int pos = lseek(fd, newsize*sizeof(TripleID)-1, SEEK_SET);
 	if(pos==-1) {
 		perror("Error lseek");
-		throw "Error lseek";
+		throw std::runtime_error("Error lseek");
 	}
 
 	char c = 0;
 	int wr = write(fd, &c, 1);
 	if(wr==-1) {
 		perror("Error write");
-		throw "Error write";
+		throw std::runtime_error("Error write");
 	}
 
 #ifndef WIN32
@@ -188,7 +188,7 @@ void TripleListDisk::load(std::istream & input, ControlInformation &controlInfor
 	// FIXME: Read controlInformation
 	std::string format = controlInformation.getFormat();
 	if(format!=getType()) {
-		throw "Trying to read a FourSectionDictionary but the data is not FourSectionDictionary";
+		throw std::runtime_error("Trying to read a FourSectionDictionary but the data is not FourSectionDictionary");
 	}
 	this->ensureSize(numTotalTriples);
 
@@ -202,7 +202,7 @@ void TripleListDisk::load(std::istream & input, ControlInformation &controlInfor
 
 size_t TripleListDisk::load(unsigned char *ptr, unsigned char *ptrMax, ProgressListener *listener)
 {
-    throw "Not implemented";
+    throw std::logic_error("Not Implemented");
 }
 
 
@@ -260,13 +260,13 @@ IteratorTripleID *TripleListDisk::search(TripleID &pattern)
 }
 
 IteratorTripleID *TripleListDisk::searchJoin(TripleID &a, TripleID &b, unsigned short conditions) {
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 float TripleListDisk::cost(TripleID & triple) const
 {
 	// TODO:
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 void TripleListDisk::generateIndex(ProgressListener *listener) {
@@ -292,7 +292,7 @@ size_t TripleListDisk::loadIndex(unsigned char *ptr, unsigned char *ptrMax, Prog
 void TripleListDisk::insert(TripleID &triple)
 {
 	if(arrayTriples==NULL) {
-		throw "Invalid pointer";
+		throw std::runtime_error("Invalid pointer");
 	}
 
 	if(numTotalTriples>=capacity) {
@@ -429,7 +429,7 @@ void TripleListDisk::removeDuplicates(ProgressListener *listener) {
 	    return;
 
     if(order==Unknown){
-	    throw "Cannot remove duplicates on unordered triples";
+	    throw std::runtime_error("Cannot remove duplicates on unordered triples");
     }
 
     unsigned int j = 0;

--- a/hdt-lib/src/triples/TripleOrderConvert.cpp
+++ b/hdt-lib/src/triples/TripleOrderConvert.cpp
@@ -149,7 +149,7 @@ The order of swaps is important, there are five different:
             return;
 
         if(from==Unknown || to==Unknown){
-        	throw "Cannot swap Unknown orders";
+        	throw std::runtime_error("Cannot swap Unknown orders");
         }
 
         bool swap1 = swap1tab[from - 1][to - 1];
@@ -178,7 +178,7 @@ void swapComponentOrder(TripleID *triple, TripleComponentOrder from, TripleCompo
         return;
 
     if(from==Unknown || to==Unknown){
-    	throw "Cannot swap Unknown orders";
+    	throw std::runtime_error("Cannot swap Unknown orders");
     }
 
     bool swap1 = swap1tab[from - 1][to - 1];
@@ -223,7 +223,7 @@ UnorderedTriple *getUnorderedTriple(TripleComponentOrder type)
 	case OPS:
 		return new UnorderedTripleOPS();
 	}
-	throw "Invalid TripleComponentOrder type";
+	throw std::runtime_error("Invalid TripleComponentOrder type");
 }
 
 TripleComponentOrder invertOrder(TripleComponentOrder src) {

--- a/hdt-lib/src/triples/TriplesComparator.cpp
+++ b/hdt-lib/src/triples/TriplesComparator.cpp
@@ -126,7 +126,7 @@ bool TriplesComparator::operator()(const TripleID &a, const TripleID &b)
 			z2 = b.getSubject();
 			break;
 		default:
-			throw "Invalid TripleComponentOrder";
+			throw std::runtime_error("Invalid TripleComponentOrder");
 	}
 
 	// Might as well use TripleID::compare()... right?

--- a/hdt-lib/src/triples/TriplesKyoto.cpp
+++ b/hdt-lib/src/triples/TriplesKyoto.cpp
@@ -57,7 +57,7 @@ int32_t TriplesKyoto::compare (const char *akbuf, size_t aksiz, const char *bkbu
         cout << endl << " compare " << *a << " = " << *b << "    = " << result << endl;
         return result;
     }
-    throw "TripleKyoto: Error comparing buffers";
+    throw std::runtime_error("TripleKyoto: Error comparing buffers");
 }
 
 TriplesKyoto::TriplesKyoto(HDTSpecification &specification) : spec(specification) {
@@ -128,13 +128,13 @@ IteratorTripleID *TriplesKyoto::search(TripleID &pattern)
 }
 
 IteratorTripleID *TriplesKyoto::searchJoin(TripleID &a, TripleID &b, unsigned short conditions) {
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 float TriplesKyoto::cost(TripleID &pattern)
 {
 	// TODO: Theoretically define this with the team
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 size_t TriplesKyoto::getNumberOfElements()
@@ -159,7 +159,7 @@ void TriplesKyoto::load(std::istream &input, ControlInformation &controlInformat
 
 size_t TriplesKyoto::load(unsigned char *ptr, unsigned char *ptrMax, ProgressListener *listener)
 {
-    throw "Not implemented";
+    throw std::logic_error("Not Implemented");
 }
 
 void TriplesKyoto::load(ModifiableTriples &input, ProgressListener *listener)
@@ -238,12 +238,12 @@ void TriplesKyoto::insert(IteratorTripleID *triples)
 
 bool TriplesKyoto::remove(TripleID &pattern)
 {
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 bool TriplesKyoto::remove(IteratorTripleID *pattern)
 {
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 void TriplesKyoto::sort(TripleComponentOrder order, ProgressListener *listener)

--- a/hdt-lib/src/triples/TriplesList.cpp
+++ b/hdt-lib/src/triples/TriplesList.cpp
@@ -64,13 +64,13 @@ IteratorTripleID *TriplesList::search(TripleID &pattern)
 }
 
 IteratorTripleID *TriplesList::searchJoin(TripleID &a, TripleID &b, unsigned short conditions) {
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 float TriplesList::cost(TripleID &pattern) const
 {
 	// TODO: Theoretically define this with the team
-	throw "Not implemented";
+	throw std::logic_error("Not Implemented");
 }
 
 size_t TriplesList::getNumberOfElements() const
@@ -103,7 +103,7 @@ void TriplesList::load(std::istream &input, ControlInformation &controlInformati
 {
 	std::string format = controlInformation.getFormat();
 	if(format!=getType()) {
-		throw "Trying to read a TriplesList but the data is not TriplesList";
+		throw std::runtime_error("Trying to read a TriplesList but the data is not TriplesList");
 	}
 
 	order = (TripleComponentOrder) controlInformation.getUint("order");
@@ -122,10 +122,10 @@ void TriplesList::load(std::istream &input, ControlInformation &controlInformati
     }
 }
 
-#define CHECKPTR(base, max, size) if(((base)+(size))>(max)) throw "Could not read completely the HDT from the file.";
+#define CHECKPTR(base, max, size) if(((base)+(size))>(max)) throw std::runtime_error("Could not read completely the HDT from the file.");
 
 size_t TriplesList::load(unsigned char *ptr, unsigned char *ptrMax, ProgressListener *listener)
-{    
+{
     size_t count=0;
 
     ControlInformation controlInformation;
@@ -133,7 +133,7 @@ size_t TriplesList::load(unsigned char *ptr, unsigned char *ptrMax, ProgressList
 
     std::string format = controlInformation.getFormat();
     if(format!=getType()) {
-        throw "Trying to read a TriplesList but the data is not TriplesList";
+        throw std::runtime_error("Trying to read a TriplesList but the data is not TriplesList");
     }
 
     order = (TripleComponentOrder) controlInformation.getUint("order");
@@ -296,7 +296,7 @@ void TriplesList::removeDuplicates(ProgressListener *listener) {
 		return;
 
 	if(order==Unknown){
-		throw "Cannot remove duplicates on unordered triples";
+		throw std::runtime_error("Cannot remove duplicates on unordered triples");
 	}
 
 	unsigned int j = 0;

--- a/hdt-lib/src/util/crc32.h
+++ b/hdt-lib/src/util/crc32.h
@@ -97,7 +97,7 @@ public:
 
 #ifdef WIN32
 		// Write by 1Mb blocks
-		const size_t BLOCK_SIZE = 8192; 
+		const size_t BLOCK_SIZE = 8192;
 		size_t counter=0;
 		char *ptr = (char *)buf;
 		while(counter<len && out.good()) {
@@ -106,7 +106,7 @@ public:
 		    counter += currByt;
 		}
 		if(counter!=len) {
-		    throw "Could not write full buffer";
+		    throw std::runtime_error("Could not write full buffer");
 		}
 #else
 		out.write((char*)buf, len);

--- a/hdt-lib/src/util/fileUtil.cpp
+++ b/hdt-lib/src/util/fileUtil.cpp
@@ -73,12 +73,12 @@ void fileUtil::decompress(const char *input, const char * output, hdt::ProgressL
 
 	ifstream inFile(input, ios::binary);
 	if(!inFile.good()) {
-		throw "Could not open input file for decompression";
+		throw std::runtime_error("Could not open input file for decompression");
 	}
 
 	ofstream outFile(output, ios::binary);
 	if(!outFile.good()) {
-		throw "Could not open output file to save decompressed data";
+		throw std::runtime_error("Could not open output file to save decompressed data");
 	}
 
 	z_stream strm;
@@ -93,7 +93,7 @@ void fileUtil::decompress(const char *input, const char * output, hdt::ProgressL
 	if (ret != Z_OK) {
 		inFile.close();
 		outFile.close();
-		throw "Error initializing libz stream";
+		throw std::runtime_error("Error initializing libz stream");
 	}
 
 	unsigned char *inBuffer = new unsigned char[CHUNK];
@@ -109,7 +109,7 @@ void fileUtil::decompress(const char *input, const char * output, hdt::ProgressL
 			inFile.close();	outFile.close();
 			delete[] inBuffer; delete[] outBuffer;
 			(void)inflateEnd(&strm);
-			throw "Cannot read file and GZIP data hasn't finished.";
+			throw std::runtime_error("Cannot read file and GZIP data hasn't finished.");
 		}
 		inFile.read((char*)inBuffer, CHUNK);
 		strm.avail_in = inFile.gcount();
@@ -134,7 +134,7 @@ void fileUtil::decompress(const char *input, const char * output, hdt::ProgressL
 
 				cerr << "zlib error code: " << ret << " => "<< strm.msg << endl;
 				(void)inflateEnd(&strm);
-				throw "Error decompressing gzip file";
+				throw std::runtime_error("Error decompressing gzip file");
 			}
 
 			unsigned int have = CHUNK - strm.avail_out;
@@ -150,10 +150,10 @@ void fileUtil::decompress(const char *input, const char * output, hdt::ProgressL
 	(void)inflateEnd(&strm);
 
 	if(ret!=Z_STREAM_END) {
-		throw "The file is damaged or truncated. Could not decompress the expected bytes. ";
+		throw std::runtime_error("The file is damaged or truncated. Could not decompress the expected bytes. ");
 	}
 #else
-	throw "Compiled without GZIP Support, please decompress the file and try again.";
+	throw std::runtime_error("Compiled without GZIP Support, please decompress the file and try again.");
 #endif
 }
 
@@ -171,7 +171,7 @@ DecompressStream::DecompressStream(const char *fileName) : in(NULL), filePipe(NU
 		#ifdef HAVE_LIBZ
 			in = gzStream = new igzstream(fileName);
 		#else
-			throw "Support for GZIP was not compiled in this version. Please Decompress the file before importing it.";
+			throw std::runtime_error("Support for GZIP was not compiled in this version. Please Decompress the file before importing it.");
 		#endif
 	}
 #else
@@ -190,7 +190,7 @@ DecompressStream::DecompressStream(const char *fileName) : in(NULL), filePipe(NU
 		pipeCommand.append(fileName);
 		if ((filePipe=popen(pipeCommand.c_str(),"r")) == NULL) {
 			cerr << "Error creating pipe for command " << pipeCommand << endl;
-			throw "popen() failed to create pipe";
+			throw std::runtime_error("popen() failed to create pipe");
 		}
 
 		in = new boost::fdistream(fileno(filePipe));
@@ -201,7 +201,7 @@ DecompressStream::DecompressStream(const char *fileName) : in(NULL), filePipe(NU
 	if (!in->good())
 	{
 		cerr << "Error opening file " << fileName << " for parsing " << endl;
-		throw "Error opening file for parsing";
+		throw std::runtime_error("Error opening file for parsing");
 	}
 }
 

--- a/hdt-lib/src/util/filemap.cpp
+++ b/hdt-lib/src/util/filemap.cpp
@@ -66,7 +66,7 @@ FileMap::FileMap(const char *fileName) : fd(0), ptr(NULL) {
     // Open file
     fd = CreateFile( (WCHAR*)fileNameString.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,NULL);
     if (fd==INVALID_HANDLE_VALUE) {
-        throw "Error creating file for mapping.";
+        throw std::runtime_error("Error creating file for mapping.");
     }
 
     // Guess size
@@ -78,7 +78,7 @@ FileMap::FileMap(const char *fileName) : fd(0), ptr(NULL) {
     h = CreateFileMapping (fd, NULL, PAGE_READONLY, upper, lower, NULL);
     if (h==NULL) {
         CloseHandle(fd);
-        throw "Error creating mapping on file";
+        throw std::runtime_error("Error creating mapping on file");
     }
 
     // Get pointer
@@ -88,7 +88,7 @@ FileMap::FileMap(const char *fileName) : fd(0), ptr(NULL) {
         CloseHandle(h);
         DWORD err = GetLastError();
         cerr << "Error getting pointer: " << err << endl;
-        throw "Error getting pointer of the mapped file";
+        throw std::runtime_error("Error getting pointer of the mapped file");
     }
 #else
     // Linux and OSX
@@ -96,20 +96,20 @@ FileMap::FileMap(const char *fileName) : fd(0), ptr(NULL) {
 	// Open file
 	fd = open(fileName, O_RDONLY);
 	if(fd<=0) {
-		throw "Error opening HDT file for mapping.";
+		throw std::runtime_error("Error opening HDT file for mapping.");
 	}
 
 	// Guess size
 	struct stat statbuf;
 	if(stat(fileName,&statbuf)!=0) {
-		throw "Error trying to guess the file size";
+		throw std::runtime_error("Error trying to guess the file size");
 	}
 	mappedSize = statbuf.st_size;
 
 	// Do mmap
 	ptr = (unsigned char *) mmap(0, mappedSize, PROT_READ, MAP_PRIVATE, fd, 0);
 	if(ptr==MAP_FAILED) {
-		throw "Error trying to mmap HDT file";
+		throw std::runtime_error("Error trying to mmap HDT file");
 	}
 
 	// Mark as needed so the OS keeps as much as possible in memory

--- a/hdt-lib/src/util/propertyutil.cpp
+++ b/hdt-lib/src/util/propertyutil.cpp
@@ -14,7 +14,7 @@ void PropertyUtil::read(const char *filename, PropertyMapT &map)
 {
     std::ifstream file(filename);
     if (!file)
-        throw "unable to open properties file";
+        throw std::runtime_error("unable to open properties file");
     read(file, map);
     file.close();
 }
@@ -22,8 +22,8 @@ void PropertyUtil::read(const char *filename, PropertyMapT &map)
 void PropertyUtil::read(std::istream &is, PropertyMapT &map)
 {
     if (!is)
-        throw "unable to read from stream";
-    
+        throw std::runtime_error("unable to read from stream");
+
     char ch = 0;
 
     ch = is.get();
@@ -33,9 +33,9 @@ void PropertyUtil::read(std::istream &is, PropertyMapT &map)
         switch (ch)
         {
         case '#' :
-        case '!' : 
+        case '!' :
             do ch = is.get();
-            while (!is.eof() && ch >= 0 && ch != '\n' && ch != '\r');               
+            while (!is.eof() && ch >= 0 && ch != '\n' && ch != '\r');
             continue;
         case '\n':
         case '\r':

--- a/hdt-lib/src/util/unicode.hpp
+++ b/hdt-lib/src/util/unicode.hpp
@@ -26,7 +26,7 @@ void appendUnicodeUTF8(std::string &str, unsigned int c) {
 	 */
 	if((c > 0xD7FF && c < 0xE000) || c == 0xFFFE || c == 0xFFFF) {
 		cerr << "Ignoring character, Unicode Range ERROR: " << hex << c << dec << endl;
-		//throw "Unicode Range ERROR";
+		//throw std::runtime_error("Unicode Range ERROR");
 	}
 
 	if      (c < 0x00000080)
@@ -42,7 +42,7 @@ void appendUnicodeUTF8(std::string &str, unsigned int c) {
 	else if(c < 0x80000000)
 		size = 6;
 	else
-		throw "Unicode ERROR";
+		throw std::runtime_error("Unicode ERROR");
 
 	switch(size) {
 	case 6:

--- a/hdt-lib/tests/confm.cpp
+++ b/hdt-lib/tests/confm.cpp
@@ -97,12 +97,7 @@ int main(int argc, char **argv) {
 		out.close();
 
 		delete hdt;
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 }
-
-
-

--- a/hdt-lib/tests/conops.cpp
+++ b/hdt-lib/tests/conops.cpp
@@ -126,12 +126,7 @@ int main(int argc, char **argv) {
 		out.close();
 
 		delete hdt;
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cout << "ERROR: " << e.what() << endl;
 	}
 }
-
-
-

--- a/hdt-lib/tests/conpfc.cpp
+++ b/hdt-lib/tests/conpfc.cpp
@@ -95,12 +95,7 @@ int main(int argc, char **argv) {
 		out.close();
 
 		delete hdt;
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cout << "ERROR: " << e.what() << endl;
 	}
 }
-
-
-

--- a/hdt-lib/tests/convert.cpp
+++ b/hdt-lib/tests/convert.cpp
@@ -66,12 +66,7 @@ int main(int argc, char **argv) {
 		hdt->saveToHDT(outputFile.c_str());
 
 		delete hdt;
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cout << "ERROR: " << e.what() << endl;
 	}
 }
-
-
-

--- a/hdt-lib/tests/conwav.cpp
+++ b/hdt-lib/tests/conwav.cpp
@@ -78,12 +78,7 @@ int main(int argc, char **argv) {
 		cout << "IN: " << inputFile << " Out: " << outputFile << endl;
 
 		delete hdt;
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cout << "ERROR: " << e.what() << endl;
 	}
 }
-
-
-

--- a/hdt-lib/tests/csd.cpp
+++ b/hdt-lib/tests/csd.cpp
@@ -71,12 +71,7 @@ int main(int argc, char **argv) {
 
 		delete csd;
 
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cout << "ERROR: " << e.what() << endl;
 	}
 }
-
-
-

--- a/hdt-lib/tests/dic.cpp
+++ b/hdt-lib/tests/dic.cpp
@@ -32,10 +32,8 @@ int main(int argc, char **argv) {
 
 		delete it;
 		delete hdt;
-	 } catch(const char *str) {
-		cerr << str << endl;
-	 } catch(char *str) {
-		cerr << str << endl;
+	 } catch(std::exception& e) {
+		cerr << e.what() << endl;
 	 }
 
 }

--- a/hdt-lib/tests/filterSearch.cpp
+++ b/hdt-lib/tests/filterSearch.cpp
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
 
 			std::ifstream file(infile.c_str());
 			if (!file.good())
-				throw "unable to open filter file";
+				throw std::runtime_error("unable to open filter file");
 
 			string linea = "";
 			string property = "";
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
 
 			while (!file.eof()) {
 				getline(file, linea);
-				if(linea.length()==0) 
+				if(linea.length()==0)
 					continue;
 				size_t pos = linea.find(';');
 
@@ -182,7 +182,7 @@ int main(int argc, char **argv) {
 						}
 						delete it;
 					}
-					
+
 					cout << ">>> Results: " << totalQueryResults << endl;
 					cerr << "Query " << numQuery << " Results: " << totalQueryResults << " in " << st << endl << endl;
 					numQuery++;
@@ -199,11 +199,7 @@ int main(int argc, char **argv) {
 		}
 
 		delete hdt;
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 }
-
-

--- a/hdt-lib/tests/genCache.cpp
+++ b/hdt-lib/tests/genCache.cpp
@@ -90,12 +90,7 @@ int main(int argc, char **argv) {
 		    out.close();
 
 		delete hdt;
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 }
-
-
-

--- a/hdt-lib/tests/genIndex.cpp
+++ b/hdt-lib/tests/genIndex.cpp
@@ -56,12 +56,7 @@ int main(int argc, char **argv) {
 		HDT *hdt = HDTManager::mapIndexedHDT(inputFile.c_str(), &progress);
 
 		delete hdt;
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 }
-
-
-

--- a/hdt-lib/tests/getobj.cpp
+++ b/hdt-lib/tests/getobj.cpp
@@ -74,12 +74,7 @@ int main(int argc, char **argv) {
 		//hdt->saveToHDT(inputFile.c_str());
 
 		delete hdt;
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 }
-
-
-

--- a/hdt-lib/tests/hdt2rdfNotMapping.cpp
+++ b/hdt-lib/tests/hdt2rdfNotMapping.cpp
@@ -117,13 +117,8 @@ int main(int argc, char **argv) {
 			delete serializer;
 		}
 		delete hdt;
-	} catch (char *exception) {
-		cerr << "ERROR: " << exception << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 
 }
-
-
-

--- a/hdt-lib/tests/hdtExtract.cpp
+++ b/hdt-lib/tests/hdtExtract.cpp
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
 			Header *header = hdt->getHeader();
 			out.open(headerFile.c_str());
 			if(!out.good()){
-				throw "Could not open Header file.";
+				throw std::runtime_error("Could not open Header file.");
 			}
 			header->save(out, controlInformation);
 			out.close();
@@ -111,7 +111,7 @@ int main(int argc, char **argv) {
 			Dictionary *dictionary = hdt->getDictionary();
 			out.open(dictionaryFile.c_str());
 			if(!out.good()){
-				throw "Could not open Dictionary file.";
+				throw std::runtime_error("Could not open Dictionary file.");
 			}
 			dictionary->save(out, controlInformation);
 			out.close();
@@ -122,17 +122,14 @@ int main(int argc, char **argv) {
 			Triples *triples = hdt->getTriples();
 			out.open(triplesFile.c_str());
 			if(!out.good()){
-				throw "Could not open Triples file.";
+				throw std::runtime_error("Could not open Triples file.");
 			}
 			triples->save(out, controlInformation);
 			out.close();
 		}
 
 		delete hdt;
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 }
-

--- a/hdt-lib/tests/iter.cpp
+++ b/hdt-lib/tests/iter.cpp
@@ -149,12 +149,7 @@ int main(int argc, char **argv) {
 
 #endif
 		delete hdt;
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 }
-
-
-

--- a/hdt-lib/tests/joinsearch.cpp
+++ b/hdt-lib/tests/joinsearch.cpp
@@ -62,7 +62,7 @@ SparqlQuery parseFile(string fileName) {
 				}
 				if(pattern.size()!=3) {
 					cout << "Pattern size: " << pattern.size() << endl;
-					throw "Pattern should have 3 components";
+					throw std::runtime_error("Pattern should have 3 components");
 				}
 				TripleString trip(pattern[0], pattern[1], pattern[2]);
 				output.patterns.push_back(trip);
@@ -140,12 +140,7 @@ int main(int argc, char **argv) {
 		delete binding;
 
 		delete hdt;
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 }
-
-
-

--- a/hdt-lib/tests/jointest.cpp
+++ b/hdt-lib/tests/jointest.cpp
@@ -95,7 +95,7 @@ SparqlQuery parseSparql(string query) {
                                         pattern[pattern.size()-1].append(last);
                                 }
                                 if(pattern.size()!=3) {
-                                        throw "Pattern should have 3 components";
+                                        throw std::runtime_error("Pattern should have 3 components");
                                 }
                                 hdt::TripleString trip(pattern[0], pattern[1], pattern[2]);
                                 output.patterns.push_back(trip);
@@ -205,7 +205,7 @@ int main(int argc, char **argv) {
 					while(binding->findNext()) {
 						for(unsigned int i=0;i<binding->getNumVars();i++) {
 							//cout << binding->getVarName(i) << "=" << binding->getVar(i) << endl;
-							cout << binding->getVar(i) << " "; 
+							cout << binding->getVar(i) << " ";
 						}
 						cout << endl;
 						count++;
@@ -219,9 +219,7 @@ int main(int argc, char **argv) {
 
 					delete binding;
 					numqueries++;
-				} catch (const char *e) {
-					cerr << "Error in query: " << line << endl;
-				} catch (char *e) {
+				} catch (std::exception& e) {
 					cerr << "Error in query: " << line << endl;
 				}
 			}
@@ -233,12 +231,7 @@ int main(int argc, char **argv) {
 		cerr << "Average time real: " << ((double)global.getReal())/numqueries << endl;
 
 		delete hdt;
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 }
-
-
-

--- a/hdt-lib/tests/mergeHdt.cpp
+++ b/hdt-lib/tests/mergeHdt.cpp
@@ -136,7 +136,7 @@ int main(int argc, char **argv) {
 		ofstream out;
 		out.open(outputFile.c_str(), ios::out | ios::binary | ios::trunc);
 		if(!out.good()){
-			throw "Could not open output file.";
+			throw std::runtime_error("Could not open output file.");
 		}
 		hdt.saveToHDT(out, &progress);
 		out.close();
@@ -151,10 +151,8 @@ int main(int argc, char **argv) {
 		if(generateIndex) {
 			(void)HDTManager::indexedHDT(&hdt, &progress);
 		}
-	} catch (char *exception) {
-		cerr << "ERROR: " << exception << endl;
-	} catch (const char *exception) {
-		cerr << "ERROR: " << exception << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 
 }

--- a/hdt-lib/tests/naiveComplete.cpp
+++ b/hdt-lib/tests/naiveComplete.cpp
@@ -184,9 +184,7 @@ int main(int argc, char **argv) {
 		}
 
 		delete hdt;
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 }

--- a/hdt-lib/tests/opendic.cpp
+++ b/hdt-lib/tests/opendic.cpp
@@ -64,12 +64,7 @@ int main(int argc, char **argv) {
 
 		ci.load(in);
 		dict.load(in, ci, &progress);
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 }
-
-
-

--- a/hdt-lib/tests/patsearch.cpp
+++ b/hdt-lib/tests/patsearch.cpp
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
 			if(line[0]=='\0'||strcmp(line, "exit")==0|| strcmp(line,"quit")==0) {
 				break;
 			}
-			
+
 			uint32_t *results = NULL;
 			hdt::LiteralDictionary *dict = dynamic_cast<hdt::LiteralDictionary *>(hdt->getDictionary());
 			if(dict!=NULL) {
@@ -94,9 +94,7 @@ int main(int argc, char **argv) {
 		}
 
 		delete hdt;
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 }

--- a/hdt-lib/tools/hdt2rdf.cpp
+++ b/hdt-lib/tools/hdt2rdf.cpp
@@ -117,13 +117,8 @@ int main(int argc, char **argv) {
 			delete serializer;
 		}
 		delete hdt;
-	} catch (char *exception) {
-		cerr << "ERROR: " << exception << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 
 }
-
-
-

--- a/hdt-lib/tools/hdtInfo.cpp
+++ b/hdt-lib/tools/hdtInfo.cpp
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
 			#ifdef HAVE_LIBZ
 				in = inGz = new igzstream(inputFile.c_str());
 			#else
-				throw "Support for GZIP was not compiled in this version. Please Decompress the file before importing it.";
+				throw std::runtime_error("Support for GZIP was not compiled in this version. Please Decompress the file before importing it.");
 			#endif
 		} else {
 			in = inF = new ifstream(inputFile.c_str(), ios::binary);
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
 		if (!in->good())
 		{
 			cerr << "Error opening file " << inputFile << endl;
-			throw "Error opening file for reading";
+			throw std::runtime_error("Error opening file for reading");
 		}
 
 		ControlInformation controlInformation;
@@ -136,7 +136,7 @@ int main(int argc, char **argv) {
 		if(outputFile!="") {
 			ofstream out(outputFile.c_str());
 			if(!out.good()){
-				throw "Could not open output file.";
+				throw std::runtime_error("Could not open output file.");
 			}
 			RDFSerializerNTriples serializer(out, NTRIPLES);
 			serializer.serialize(it);
@@ -149,12 +149,7 @@ int main(int argc, char **argv) {
 
 		delete header;
 
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 }
-
-
-

--- a/hdt-lib/tools/hdtSearch.cpp
+++ b/hdt-lib/tools/hdtSearch.cpp
@@ -99,8 +99,8 @@ void iterate(HDT *hdt, char *query, ostream &out, bool measure) {
 		delete it;
 
 		interruptSignal=0;	// Interrupt caught, enable again.
-	} catch (char *e) {
-		cerr << e << endl;
+	} catch (std::exception& e) {
+		cerr << e.what() << endl;
 	}
 
 }
@@ -186,12 +186,7 @@ int main(int argc, char **argv) {
 		}
 
 		delete hdt;
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 }
-
-
-

--- a/hdt-lib/tools/rdf2hdt.cpp
+++ b/hdt-lib/tools/rdf2hdt.cpp
@@ -157,7 +157,7 @@ int main(int argc, char **argv) {
 		// Save HDT
 		out.open(outputFile.c_str(), ios::out | ios::binary | ios::trunc);
 		if(!out.good()){
-			throw "Could not open output file.";
+			throw std::runtime_error("Could not open output file.");
 		}
 		hdt->saveToHDT(out, &progress);
 		out.close();
@@ -174,10 +174,8 @@ int main(int argc, char **argv) {
 		}
 
 		delete hdt;
-	} catch (char *exception) {
-		cerr << "ERROR: " << exception << endl;
-	} catch (const char *exception) {
-		cerr << "ERROR: " << exception << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 
 }

--- a/hdt-lib/tools/replaceHeader.cpp
+++ b/hdt-lib/tools/replaceHeader.cpp
@@ -60,9 +60,7 @@ int main(int argc, char **argv) {
 		hdt->saveToHDT(outputFile);
 
 		delete hdt;
-	} catch (char *e) {
-		cout << "ERROR: " << e << endl;
-	} catch (const char *e) {
-		cout << "ERROR: " << e << endl;
+	} catch (std::exception& e) {
+		cerr << "ERROR: " << e.what() << endl;
 	}
 }


### PR DESCRIPTION
I took a first stab at improving the exception handling (related to https://github.com/rdfhdt/hdt-cpp/issues/18).
Notes:

* I only modified hdt-lib, not hdt-it
* If a catch clause did not rethrow an exception, I left that as is.(except changing the caught type to  `exception`)
* Only in a very few cases (in the parsing code) I changed cerr statements to throw exceptions instead. In most cases, it was too risky to estimate whether these were warnings or blocking exceptions, so I left them as-is. For those cases where errors were printed to cout, I modified them to print to cerr
* I replaced all string-throws to runtime_error exceptions. Unimplemented or Unsupported string errors were replace with `logic_error` exceptions. Parsing related stuff now throws the `ParseException` from `RDFParser.hpp`.
* For all catch clauses that rethrow an exception _and_ print the message to cerr, I commented-out the cerr statement.
* For all catch clauses that simply rethrew an exception and did nothing else (e.g. mem cleanup), I simply removed the try catch.


These changes may have a high impact: string exceptions that are thrown by dependencies or code I missed won't be caught anymore. Vice versa, throws of type `exception` that weren't caught before at an early stage, are now caught by the modified catch clauses.
And, I expect more cleanup needs to be done (by someone with a more thorough understanding of the code) to remove the abundance of catch clauses, to replace more `cerr` statements with regular throws, and to e.g. replace some of the `exception` objects with more detailed subclass exceptions.
