### PR TITLE
Add configurable version number to software and index files

### DIFF
--- a/hdt-lib/include/HDTVersion.hpp
+++ b/hdt-lib/include/HDTVersion.hpp
@@ -1,45 +1,39 @@
-#define HDT_VERSION "1"
-#define INDEX_VERSION "1"
-#define RELEASE_VERSION "1"
 /*
-using namespace std;
+ * File: HDTVersion.cpp
+ * Last modified: $Date$
+ * Revision: $Revision$
+ * Last modified by: $Author$
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Contacting the authors:
+ *   Mario Arias:               mario.arias@gmail.com
+ *   Javier D. Fernandez:       jfergar@infor.uva.es
+ *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
+ *
+ * This file determines the current version of the software.
+ * The total version number is: v<HDT_version>.<INDEX_VERSION>.<RELEASE_VERSION>
+ */
 
-namespace hdt {
-  // Parses version URI
-  inline std::vector<int> parse_version_uri(std::string uri) {
-    std::string version_base = HDTVocabulary::HDT_BASE+"HDTv";
-    std::size_t found = uri.find(version_base);
-    if (found==std::string::npos)
-      throw "Invalid version URI";
+// Version of the actual HDT file that is generated or read.
+// Software must be backwards compatible with all HDT files with the same number.
+#define HDT_VERSION "1"
 
-    std::cout << "first 'needle' found at: " << found << '\n';
+// Version of the accompagning .index file that is generated or read
+// Software must be backwards compatible with all index files with the same index and HDT version number.
+#define INDEX_VERSION "1"
 
-    uri.substr(version_base.length(), uri.length() - version_base.length() - 1); // remove trailing ">"
-
-    // Parse version number
-    // First number is HDT, second is Index, Third is release
-    std::vector<int> result(3);
-    std::string delimiter = "-";
-    // Find first
-    found = uri.find(delimiter);
-    if (!found)
-      throw "Invalid version URI";
-
-    int hdt_version = stoi(uri.substr(0, found));
-
-    found = uri.find(delimiter, found + 1);
-    if (!found)
-      return { hdt_version, 0, 0 };
-
-    int index_version = stoi(uri.substr(0, found));
-
-    found = uri.find(delimiter, found + 1);
-    if (!found)
-      return { hdt_version, index_version, 0 };
-
-    int release_version = stoi(uri.substr(0, found));
-
-    return { hdt_version, index_version, 0 };
-  }
-}
-*/
+// Subreleases that are backwards compatible with both HDT and index file
+#define RELEASE_VERSION "1"

--- a/hdt-lib/include/HDTVersion.hpp
+++ b/hdt-lib/include/HDTVersion.hpp
@@ -27,6 +27,9 @@
  * The total version number is: v<HDT_version>.<INDEX_VERSION>.<RELEASE_VERSION>
  */
 
+ #ifndef HDT_HDTVERSION_HPP_
+ #define HDT_HDTVERSION_HPP_
+
 // Version of the actual HDT file that is generated or read.
 // Software must be backwards compatible with all HDT files with the same number.
 #define HDT_VERSION "1"
@@ -37,3 +40,14 @@
 
 // Subreleases that are backwards compatible with both HDT and index file
 #define RELEASE_VERSION "1"
+
+#include <string>
+
+namespace hdt {
+namespace HDTVersion {
+    inline std::string get_version_string(std::string delimiter) {
+      return std::string("v") + HDT_VERSION + delimiter + INDEX_VERSION + delimiter + RELEASE_VERSION;
+    };
+}
+}
+#endif /* HDT_HDTVERSION_HPP_ */

--- a/hdt-lib/include/HDTVersion.hpp
+++ b/hdt-lib/include/HDTVersion.hpp
@@ -49,8 +49,8 @@ namespace HDTVersion {
       return std::string("v") + HDT_VERSION + delimiter + INDEX_VERSION + delimiter + RELEASE_VERSION;
     };
 
-    inline std::string get_index_suffix() {
-      return std::string(".index.v") + HDT_VERSION + INDEX_VERSION;
+    inline std::string get_index_suffix(std::string delimiter) {
+      return std::string(".index.v") + HDT_VERSION + delimiter+INDEX_VERSION;
     };
 }
 }

--- a/hdt-lib/include/HDTVersion.hpp
+++ b/hdt-lib/include/HDTVersion.hpp
@@ -1,0 +1,45 @@
+#define HDT_VERSION "1"
+#define INDEX_VERSION "1"
+#define RELEASE_VERSION "1"
+/*
+using namespace std;
+
+namespace hdt {
+  // Parses version URI
+  inline std::vector<int> parse_version_uri(std::string uri) {
+    std::string version_base = HDTVocabulary::HDT_BASE+"HDTv";
+    std::size_t found = uri.find(version_base);
+    if (found==std::string::npos)
+      throw "Invalid version URI";
+
+    std::cout << "first 'needle' found at: " << found << '\n';
+
+    uri.substr(version_base.length(), uri.length() - version_base.length() - 1); // remove trailing ">"
+
+    // Parse version number
+    // First number is HDT, second is Index, Third is release
+    std::vector<int> result(3);
+    std::string delimiter = "-";
+    // Find first
+    found = uri.find(delimiter);
+    if (!found)
+      throw "Invalid version URI";
+
+    int hdt_version = stoi(uri.substr(0, found));
+
+    found = uri.find(delimiter, found + 1);
+    if (!found)
+      return { hdt_version, 0, 0 };
+
+    int index_version = stoi(uri.substr(0, found));
+
+    found = uri.find(delimiter, found + 1);
+    if (!found)
+      return { hdt_version, index_version, 0 };
+
+    int release_version = stoi(uri.substr(0, found));
+
+    return { hdt_version, index_version, 0 };
+  }
+}
+*/

--- a/hdt-lib/include/HDTVersion.hpp
+++ b/hdt-lib/include/HDTVersion.hpp
@@ -39,7 +39,7 @@
 #define INDEX_VERSION "1"
 
 // Subreleases that are backwards compatible with both HDT and index file
-#define RELEASE_VERSION "1"
+#define RELEASE_VERSION "2"
 
 #include <string>
 

--- a/hdt-lib/include/HDTVersion.hpp
+++ b/hdt-lib/include/HDTVersion.hpp
@@ -48,6 +48,10 @@ namespace HDTVersion {
     inline std::string get_version_string(std::string delimiter) {
       return std::string("v") + HDT_VERSION + delimiter + INDEX_VERSION + delimiter + RELEASE_VERSION;
     };
+
+    inline std::string get_index_suffix() {
+      return std::string(".index.v") + HDT_VERSION + INDEX_VERSION;
+    };
 }
 }
 #endif /* HDT_HDTVERSION_HPP_ */

--- a/hdt-lib/include/HDTVocabulary.hpp
+++ b/hdt-lib/include/HDTVocabulary.hpp
@@ -33,12 +33,13 @@
 #define HDT_HDTVOCABULARY_HPP_
 
 #include <string>
+#include <HDTVersion.hpp>
 
 namespace hdt {
 namespace HDTVocabulary {
 	// Base
 	const std::string HDT_BASE = "<http://purl.org/HDT/hdt#";
-	const std::string HDT_CONTAINER = HDT_BASE+"HDTv1>";
+	const std::string HDT_CONTAINER = HDT_BASE+"HDTv"+HDT_VERSION+">";
 	const std::string HDT_HEADER = HDT_BASE+"header";
 	const std::string HDT_DICTIONARY_BASE = HDT_BASE+"dictionary";
 	const std::string HDT_DICTIONARY = HDT_DICTIONARY_BASE+">";

--- a/hdt-lib/include/HDTVocabulary.hpp
+++ b/hdt-lib/include/HDTVocabulary.hpp
@@ -39,7 +39,8 @@ namespace hdt {
 namespace HDTVocabulary {
 	// Base
 	const std::string HDT_BASE = "<http://purl.org/HDT/hdt#";
-	const std::string HDT_CONTAINER = HDT_BASE+"HDTv"+HDT_VERSION+">";
+	const std::string HDT_CONTAINER = HDT_BASE+"HDTv" + HDTVersion::get_version_string("-") + ">";
+	const std::string HDT_CONTAINER_BASE = HDT_BASE+"HDTv" + HDT_VERSION;
 	const std::string HDT_HEADER = HDT_BASE+"header";
 	const std::string HDT_DICTIONARY_BASE = HDT_BASE+"dictionary";
 	const std::string HDT_DICTIONARY = HDT_DICTIONARY_BASE+">";

--- a/hdt-lib/include/HDTVocabulary.hpp
+++ b/hdt-lib/include/HDTVocabulary.hpp
@@ -39,7 +39,7 @@ namespace hdt {
 namespace HDTVocabulary {
 	// Base
 	const std::string HDT_BASE = "<http://purl.org/HDT/hdt#";
-	const std::string HDT_CONTAINER = HDT_BASE+"HDTv" + HDTVersion::get_version_string("-") + ">";
+	const std::string HDT_CONTAINER = HDT_BASE+"HDT" + HDTVersion::get_version_string("-") + ">";
 	const std::string HDT_CONTAINER_BASE = HDT_BASE+"HDTv" + HDT_VERSION;
 	const std::string HDT_HEADER = HDT_BASE+"header";
 	const std::string HDT_DICTIONARY_BASE = HDT_BASE+"dictionary";

--- a/hdt-lib/src/hdt/BasicHDT.cpp
+++ b/hdt-lib/src/hdt/BasicHDT.cpp
@@ -779,7 +779,7 @@ size_t BasicHDT::loadMMapIndex(ProgressListener *listener) {
     }
 
     // Get path
-    string indexFile(fileName + ".index.v" + HDT_VERSION + INDEX_VERSION);
+    string indexFile(fileName + HDTVersion::get_index_suffix());
 
     mappedIndex = new FileMap(indexFile.c_str());
 
@@ -837,7 +837,7 @@ void BasicHDT::saveToHDT(std::ostream & output, ProgressListener *listener)
 
 void BasicHDT::loadOrCreateIndex(ProgressListener *listener) {
 
-	string indexname = this->fileName + ".index.v" + HDT_VERSION + INDEX_VERSION;
+	string indexname = this->fileName + HDTVersion::get_index_suffix();
 
 	ifstream in(indexname.c_str(), ios::binary);
 
@@ -868,7 +868,7 @@ void BasicHDT::saveIndex(ProgressListener *listener) {
 		return;
 	}
 
-	string indexname = this->fileName + ".index.v" + HDT_VERSION + INDEX_VERSION;
+	string indexname = this->fileName + HDTVersion::get_index_suffix();
 	ofstream out(indexname.c_str(), ios::binary);
 	ControlInformation ci;
 	triples->saveIndex(out, ci, listener);

--- a/hdt-lib/src/hdt/BasicHDT.cpp
+++ b/hdt-lib/src/hdt/BasicHDT.cpp
@@ -745,6 +745,7 @@ size_t BasicHDT::loadMMap(unsigned char *ptr, unsigned char *ptrMax, ProgressLis
     count+=controlInformation.load(&ptr[count], ptrMax);
     std::string hdtFormat = controlInformation.getFormat();
     //if(hdtFormat!=HDTVocabulary::HDT_CONTAINER) {
+    cout<<HDTVocabulary::HDT_CONTAINER_BASE<<endl;
     if (hdtFormat.find(HDTVocabulary::HDT_CONTAINER_BASE) == std::string::npos) {
     	throw std::runtime_error("This software (v" + std::string(HDT_VERSION) + ".x.x) cannot open this version of HDT File (" + hdtFormat + ")");
     }
@@ -780,7 +781,7 @@ size_t BasicHDT::loadMMapIndex(ProgressListener *listener) {
     }
 
     // Get path
-    string indexFile(fileName + HDTVersion::get_index_suffix());
+    string indexFile(fileName + HDTVersion::get_index_suffix("-"));
 
     mappedIndex = new FileMap(indexFile.c_str());
 
@@ -838,10 +839,14 @@ void BasicHDT::saveToHDT(std::ostream & output, ProgressListener *listener)
 
 void BasicHDT::loadOrCreateIndex(ProgressListener *listener) {
 
-	string indexname = this->fileName + HDTVersion::get_index_suffix();
+	string indexname = this->fileName + HDTVersion::get_index_suffix("-");
 
 	ifstream in(indexname.c_str(), ios::binary);
-
+	// backward compatibility
+	if(!in.good()) {
+		 indexname = this->fileName+".index";
+		 in.open(indexname.c_str(), ios::binary);
+	}
 	if(in.good()) {
         if(mappedHDT) {
             // Map
@@ -869,7 +874,7 @@ void BasicHDT::saveIndex(ProgressListener *listener) {
 		return;
 	}
 
-	string indexname = this->fileName + HDTVersion::get_index_suffix();
+	string indexname = this->fileName + HDTVersion::get_index_suffix("-");
 	ofstream out(indexname.c_str(), ios::binary);
 	ControlInformation ci;
 	triples->saveIndex(out, ci, listener);

--- a/hdt-lib/src/hdt/BasicHDT.cpp
+++ b/hdt-lib/src/hdt/BasicHDT.cpp
@@ -30,6 +30,7 @@
 #include <string>
 #include <time.h>
 
+#include <HDTVersion.hpp>
 #include <HDTVocabulary.hpp>
 #include <RDFParser.hpp>
 
@@ -656,7 +657,7 @@ void BasicHDT::loadFromHDT(std::istream & input, ProgressListener *listener)
 	controlInformation.load(input);
 	std::string hdtFormat = controlInformation.getFormat();
 	if(hdtFormat!=HDTVocabulary::HDT_CONTAINER) {
-		throw std::runtime_error("This software cannot open this version of HDT File.");
+		throw std::runtime_error("This software cannot open this version of HDT File (" + hdtFormat + " =/= " + HDTVocabulary::HDT_CONTAINER + ")");
 	}
 
 	// Load header
@@ -742,7 +743,7 @@ size_t BasicHDT::loadMMap(unsigned char *ptr, unsigned char *ptrMax, ProgressLis
     count+=controlInformation.load(&ptr[count], ptrMax);
     std::string hdtFormat = controlInformation.getFormat();
     if(hdtFormat!=HDTVocabulary::HDT_CONTAINER) {
-    	throw std::runtime_error("This software cannot open this version of HDT File.");
+    	throw std::runtime_error("This software cannot open this version of HDT File (" + hdtFormat + " =/= " + HDTVocabulary::HDT_CONTAINER + ")");
     }
 
     // Load Header
@@ -777,7 +778,9 @@ size_t BasicHDT::loadMMapIndex(ProgressListener *listener) {
 
     // Get path
     string indexFile(fileName);
-    indexFile.append(".index");
+    indexFile.append(".index.v");
+		indexFile.append(HDT_VERSION);
+		indexFile.append(INDEX_VERSION);
 
     mappedIndex = new FileMap(indexFile.c_str());
 
@@ -835,7 +838,7 @@ void BasicHDT::saveToHDT(std::ostream & output, ProgressListener *listener)
 
 void BasicHDT::loadOrCreateIndex(ProgressListener *listener) {
 
-	string indexname = this->fileName + ".index";
+	string indexname = this->fileName + ".index.v" + HDT_VERSION + INDEX_VERSION;
 
 	ifstream in(indexname.c_str(), ios::binary);
 
@@ -866,7 +869,7 @@ void BasicHDT::saveIndex(ProgressListener *listener) {
 		return;
 	}
 
-	string indexname = this->fileName + ".index";
+	string indexname = this->fileName + ".index.v" + HDT_VERSION + INDEX_VERSION;
 	ofstream out(indexname.c_str(), ios::binary);
 	ControlInformation ci;
 	triples->saveIndex(out, ci, listener);

--- a/hdt-lib/src/hdt/BasicHDT.cpp
+++ b/hdt-lib/src/hdt/BasicHDT.cpp
@@ -777,10 +777,7 @@ size_t BasicHDT::loadMMapIndex(ProgressListener *listener) {
     }
 
     // Get path
-    string indexFile(fileName);
-    indexFile.append(".index.v");
-		indexFile.append(HDT_VERSION);
-		indexFile.append(INDEX_VERSION);
+    string indexFile(fileName + ".index.v" + HDT_VERSION + INDEX_VERSION);
 
     mappedIndex = new FileMap(indexFile.c_str());
 

--- a/hdt-lib/src/hdt/BasicHDT.cpp
+++ b/hdt-lib/src/hdt/BasicHDT.cpp
@@ -656,8 +656,9 @@ void BasicHDT::loadFromHDT(std::istream & input, ProgressListener *listener)
 	// Load Global ControlInformation.
 	controlInformation.load(input);
 	std::string hdtFormat = controlInformation.getFormat();
-	if(hdtFormat!=HDTVocabulary::HDT_CONTAINER) {
-		throw std::runtime_error("This software cannot open this version of HDT File (" + hdtFormat + " =/= " + HDTVocabulary::HDT_CONTAINER + ")");
+	//if(hdtFormat!=HDTVocabulary::HDT_CONTAINER) {
+	if (hdtFormat.find(HDTVocabulary::HDT_CONTAINER_BASE) == std::string::npos) {
+		throw std::runtime_error("This software (v" + std::string(HDT_VERSION) + ".x.x) cannot open this version of HDT File (" + hdtFormat + ")");
 	}
 
 	// Load header
@@ -742,8 +743,9 @@ size_t BasicHDT::loadMMap(unsigned char *ptr, unsigned char *ptrMax, ProgressLis
     // Load Global ControlInformation
     count+=controlInformation.load(&ptr[count], ptrMax);
     std::string hdtFormat = controlInformation.getFormat();
-    if(hdtFormat!=HDTVocabulary::HDT_CONTAINER) {
-    	throw std::runtime_error("This software cannot open this version of HDT File (" + hdtFormat + " =/= " + HDTVocabulary::HDT_CONTAINER + ")");
+		//if(hdtFormat!=HDTVocabulary::HDT_CONTAINER) {
+		if (hdtFormat.find(HDTVocabulary::HDT_CONTAINER_BASE) == std::string::npos) {
+    	throw std::runtime_error("This software (v" + std::string(HDT_VERSION) + ".x.x) cannot open this version of HDT File (" + hdtFormat + ")");
     }
 
     // Load Header

--- a/hdt-lib/src/hdt/BasicHDT.cpp
+++ b/hdt-lib/src/hdt/BasicHDT.cpp
@@ -656,8 +656,8 @@ void BasicHDT::loadFromHDT(std::istream & input, ProgressListener *listener)
 	// Load Global ControlInformation.
 	controlInformation.load(input);
 	std::string hdtFormat = controlInformation.getFormat();
-	//if(hdtFormat!=HDTVocabulary::HDT_CONTAINER) {
-	if (hdtFormat.find(HDTVocabulary::HDT_CONTAINER_BASE) == std::string::npos) {
+  //if(hdtFormat!=HDTVocabulary::HDT_CONTAINER) {
+  if (hdtFormat.find(HDTVocabulary::HDT_CONTAINER_BASE) == std::string::npos) {
 		throw std::runtime_error("This software (v" + std::string(HDT_VERSION) + ".x.x) cannot open this version of HDT File (" + hdtFormat + ")");
 	}
 
@@ -743,8 +743,8 @@ size_t BasicHDT::loadMMap(unsigned char *ptr, unsigned char *ptrMax, ProgressLis
     // Load Global ControlInformation
     count+=controlInformation.load(&ptr[count], ptrMax);
     std::string hdtFormat = controlInformation.getFormat();
-		//if(hdtFormat!=HDTVocabulary::HDT_CONTAINER) {
-		if (hdtFormat.find(HDTVocabulary::HDT_CONTAINER_BASE) == std::string::npos) {
+    //if(hdtFormat!=HDTVocabulary::HDT_CONTAINER) {
+    if (hdtFormat.find(HDTVocabulary::HDT_CONTAINER_BASE) == std::string::npos) {
     	throw std::runtime_error("This software (v" + std::string(HDT_VERSION) + ".x.x) cannot open this version of HDT File (" + hdtFormat + ")");
     }
 

--- a/hdt-lib/tools/hdt2rdf.cpp
+++ b/hdt-lib/tools/hdt2rdf.cpp
@@ -63,8 +63,7 @@ int main(int argc, char **argv) {
 			break;
 		case 'V':
 			cout << "v" << HDT_VERSION << "." << INDEX_VERSION << "." << RELEASE_VERSION << endl;
-			return 1;
-			break;
+			return 0;
 		default:
 			cout << "ERROR: Unknown option" << endl;
 			help();

--- a/hdt-lib/tools/hdt2rdf.cpp
+++ b/hdt-lib/tools/hdt2rdf.cpp
@@ -29,6 +29,7 @@
  *
  */
 
+#include <HDTVersion.hpp>
 #include <HDT.hpp>
 #include <HDTManager.hpp>
 
@@ -44,6 +45,7 @@ void help() {
 	cout << "$ hdt2rdf [options] <HDT input file> <RDF output file> " << endl;
 	cout << "\t-h\t\t\tThis help" << endl;
 	cout << "\t-f\t<format>\tRDF Format of the output" << endl;
+	cout << "\t-V\tPrints the HDT version number." << endl;
 	//cout << "\t-v\tVerbose output" << endl;
 
 }
@@ -53,11 +55,15 @@ int main(int argc, char **argv) {
 	string rdfFormat, inputFile, outputFile;
 	RDFNotation notation = NTRIPLES;
 
-	while( (c = getopt(argc,argv,"f:"))!=-1) {
+	while( (c = getopt(argc,argv,"f:V:"))!=-1) {
 		switch(c) {
 		case 'f':
 			rdfFormat = optarg;
 			cout << "Format: " << rdfFormat << endl;
+			break;
+		case 'V':
+			cout << "v" << HDT_VERSION << "." << INDEX_VERSION << "." << RELEASE_VERSION << endl;
+			return 1;
 			break;
 		default:
 			cout << "ERROR: Unknown option" << endl;

--- a/hdt-lib/tools/hdt2rdf.cpp
+++ b/hdt-lib/tools/hdt2rdf.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
 			cout << "Format: " << rdfFormat << endl;
 			break;
 		case 'V':
-			cout << "v" << HDT_VERSION << "." << INDEX_VERSION << "." << RELEASE_VERSION << endl;
+			cout << HDTVersion::get_version_string(".") << endl;
 			return 0;
 		default:
 			cout << "ERROR: Unknown option" << endl;

--- a/hdt-lib/tools/hdtInfo.cpp
+++ b/hdt-lib/tools/hdtInfo.cpp
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
 			outputFile = optarg;
 			break;
 		case 'V':
-			cout << "v" << HDT_VERSION << "." << INDEX_VERSION << "." << RELEASE_VERSION << endl;
+			cout << HDTVersion::get_version_string(".") << endl;
 			return 0;
 		default:
 			cout << "ERROR: Unknown option" << endl;

--- a/hdt-lib/tools/hdtInfo.cpp
+++ b/hdt-lib/tools/hdtInfo.cpp
@@ -29,7 +29,7 @@
  *
  */
 
-
+#include <HDTVersion.hpp>
 #include <HDT.hpp>
 
 #include "../src/hdt/HDTFactory.hpp"
@@ -51,6 +51,7 @@ void help() {
 	cout << "$ hdtInfo [options] <hdtfile> " << endl;
 	cout << "\t-h\t\t\tThis help" << endl;
 	cout << "\t-o\t<output>\tSave query output to file." << endl;
+	cout << "\t-V\tPrints the HDT version number." << endl;
 }
 
 
@@ -65,6 +66,10 @@ int main(int argc, char **argv) {
 			break;
 		case 'o':
 			outputFile = optarg;
+			break;
+		case 'V':
+			cout << "v" << HDT_VERSION << "." << INDEX_VERSION << "." << RELEASE_VERSION << endl;
+			return 1;
 			break;
 		default:
 			cout << "ERROR: Unknown option" << endl;

--- a/hdt-lib/tools/hdtInfo.cpp
+++ b/hdt-lib/tools/hdtInfo.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
 	int c;
 	string outputFile;
 
-	while( (c = getopt(argc,argv,"ho:"))!=-1) {
+	while( (c = getopt(argc,argv,"ho:V"))!=-1) {
 		switch(c) {
 		case 'h':
 			help();
@@ -69,8 +69,7 @@ int main(int argc, char **argv) {
 			break;
 		case 'V':
 			cout << "v" << HDT_VERSION << "." << INDEX_VERSION << "." << RELEASE_VERSION << endl;
-			return 1;
-			break;
+			return 0;
 		default:
 			cout << "ERROR: Unknown option" << endl;
 			help();

--- a/hdt-lib/tools/hdtSearch.cpp
+++ b/hdt-lib/tools/hdtSearch.cpp
@@ -127,8 +127,7 @@ int main(int argc, char **argv) {
 			break;
 		case 'V':
 			cout << "v" << HDT_VERSION << "." << INDEX_VERSION << "." << RELEASE_VERSION << endl;
-			return 1;
-			break;
+			return 0;
 		default:
 			cout << "ERROR: Unknown option" << endl;
 			help();

--- a/hdt-lib/tools/hdtSearch.cpp
+++ b/hdt-lib/tools/hdtSearch.cpp
@@ -126,7 +126,7 @@ int main(int argc, char **argv) {
 			measure = true;
 			break;
 		case 'V':
-			cout << "v" << HDT_VERSION << "." << INDEX_VERSION << "." << RELEASE_VERSION << endl;
+			cout << HDTVersion::get_version_string(".") << endl;
 			return 0;
 		default:
 			cout << "ERROR: Unknown option" << endl;

--- a/hdt-lib/tools/hdtSearch.cpp
+++ b/hdt-lib/tools/hdtSearch.cpp
@@ -30,6 +30,7 @@
  */
 #include <iomanip>
 
+#include <HDTVersion.hpp>
 #include <HDT.hpp>
 #include <HDTManager.hpp>
 #include <signal.h>
@@ -57,7 +58,7 @@ void help() {
 	cout << "\t-q\t<query>\t\tLaunch query and exit." << endl;
 	cout << "\t-o\t<output>\tSave query output to file." << endl;
 	cout << "\t-m\t\t\tDo not show results, just measure query time." << endl;
-
+	cout << "\t-V\tPrints the HDT version number." << endl;
 	//cout << "\t-v\tVerbose output" << endl;
 }
 
@@ -110,7 +111,7 @@ int main(int argc, char **argv) {
 	string query, inputFile, outputFile;
 	bool measure = false;
 
-	while( (c = getopt(argc,argv,"hq:o:m"))!=-1) {
+	while( (c = getopt(argc,argv,"hq:o:m:V"))!=-1) {
 		switch(c) {
 		case 'h':
 			help();
@@ -123,6 +124,10 @@ int main(int argc, char **argv) {
 			break;
 		case 'm':
 			measure = true;
+			break;
+		case 'V':
+			cout << "v" << HDT_VERSION << "." << INDEX_VERSION << "." << RELEASE_VERSION << endl;
+			return 1;
 			break;
 		default:
 			cout << "ERROR: Unknown option" << endl;

--- a/hdt-lib/tools/rdf2hdt.cpp
+++ b/hdt-lib/tools/rdf2hdt.cpp
@@ -29,6 +29,7 @@
  *
  */
 
+#include <HDTVersion.hpp>
 #include <HDT.hpp>
 #include <HDTManager.hpp>
 
@@ -51,6 +52,7 @@ void help() {
 	cout << "\t-o\t<options>\tHDT Additional options (option1=value1;option2=value2;...)" << endl;
 	cout << "\t-f\t<format>\tFormat of the RDF input (ntriples, nquad, n3, turtle, rdfxml)" << endl;
 	cout << "\t-B\t\"<base URI>\"\tBase URI of the dataset." << endl;
+	cout << "\t-V\tPrints the HDT version number." << endl;
 	//cout << "\t-v\tVerbose output" << endl;
 }
 
@@ -67,7 +69,7 @@ int main(int argc, char **argv) {
 	RDFNotation notation = NTRIPLES;
 
 	int c;
-	while( (c = getopt(argc,argv,"c:o:vf:B:i"))!=-1) {
+	while( (c = getopt(argc,argv,"c:o:vf:B:i:V"))!=-1) {
 		switch(c) {
 		case 'c':
 			configFile = optarg;
@@ -89,6 +91,10 @@ int main(int argc, char **argv) {
 			break;
 		case 'i':
 			generateIndex=true;
+			break;
+		case 'V':
+			cout << "v" << HDT_VERSION << "." << INDEX_VERSION << "." << RELEASE_VERSION << endl;
+			return 1;
 			break;
 		default:
 			cout << "ERROR: Unknown option" << endl;

--- a/hdt-lib/tools/rdf2hdt.cpp
+++ b/hdt-lib/tools/rdf2hdt.cpp
@@ -94,8 +94,7 @@ int main(int argc, char **argv) {
 			break;
 		case 'V':
 			cout << "v" << HDT_VERSION << "." << INDEX_VERSION << "." << RELEASE_VERSION << endl;
-			return 1;
-			break;
+			return 0;
 		default:
 			cout << "ERROR: Unknown option" << endl;
 			help();

--- a/hdt-lib/tools/rdf2hdt.cpp
+++ b/hdt-lib/tools/rdf2hdt.cpp
@@ -93,7 +93,7 @@ int main(int argc, char **argv) {
 			generateIndex=true;
 			break;
 		case 'V':
-			cout << "v" << HDT_VERSION << "." << INDEX_VERSION << "." << RELEASE_VERSION << endl;
+			cout << HDTVersion::get_version_string(".") << endl;
 			return 0;
 		default:
 			cout << "ERROR: Unknown option" << endl;


### PR DESCRIPTION
This PR implements a more manageable versioning approach to prevent compatibility issues with HDT or index files.
- all tools now print a `vX.Y.Z` version number when using the `-V` (capital) cmd parameter
- index files are generated with a `.vXY` suffix
- HDT file compatibility is checked and ensured with matching `X`
- index file compatibility is ensured with matching `X` and `Y`
- Backwards compatibility is ensured between matching `X` and `Y`, but increasing `Z`.
