### PR TITLE
added missing includes for runtime_error

### DIFF
--- a/hdt-lib/include/Header.hpp
+++ b/hdt-lib/include/Header.hpp
@@ -35,7 +35,7 @@
 #include "RDF.hpp"
 #include "ControlInformation.hpp"
 #include "HDTListener.hpp"
-
+#include <stdexcept>
 #include <iostream>
 #include <sstream>
 

--- a/hdt-lib/include/SingleTriple.hpp
+++ b/hdt-lib/include/SingleTriple.hpp
@@ -33,7 +33,7 @@
 #define HDT_SINGLETRIPLE_HPP_
 
 #include "HDTEnums.hpp"
-
+#include <stdexcept>
 #include <iostream>
 #include <string>
 #include <vector>

--- a/hdt-lib/src/bitsequence/BitSequence375.cpp
+++ b/hdt-lib/src/bitsequence/BitSequence375.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <cassert>
+#include <stdexcept>
 #include <cmath>
 #include <string.h>
 

--- a/hdt-lib/src/dictionary/FourSectionDictionary.cpp
+++ b/hdt-lib/src/dictionary/FourSectionDictionary.cpp
@@ -33,7 +33,7 @@
 
 #include "FourSectionDictionary.hpp"
 #include <HDTVocabulary.hpp>
-
+#include <stdexcept>
 #include "../libdcs/CSD_PFC.h"
 #include "../libdcs/CSD_HTFC.h"
 #include "../libdcs/CSD_Cache.h"

--- a/hdt-lib/src/dictionary/KyotoDictionary.cpp
+++ b/hdt-lib/src/dictionary/KyotoDictionary.cpp
@@ -31,7 +31,7 @@
 
 #include <sstream>
 #include <unistd.h>
-
+#include <stdexcept>
 #include "KyotoDictionary.hpp"
 
 #include <HDTVocabulary.hpp>

--- a/hdt-lib/src/dictionary/LiteralDictionary.cpp
+++ b/hdt-lib/src/dictionary/LiteralDictionary.cpp
@@ -31,6 +31,7 @@
 
 #if HAVE_CDS
 
+#include <stdexcept>
 #include "LiteralDictionary.hpp"
 #include <HDTVocabulary.hpp>
 #include "../libdcs/CSD_PFC.h"

--- a/hdt-lib/src/dictionary/PlainDictionary.cpp
+++ b/hdt-lib/src/dictionary/PlainDictionary.cpp
@@ -30,7 +30,7 @@
  */
 
 #include <sstream>
-
+#include <stdexcept>
 #include "PlainDictionary.hpp"
 #include "../util/Histogram.h"
 

--- a/hdt-lib/src/hdt/BasicHDT.cpp
+++ b/hdt-lib/src/hdt/BasicHDT.cpp
@@ -27,9 +27,9 @@
 
 #include <iomanip>
 #include <algorithm>
+#include <stdexcept>
 #include <string>
 #include <time.h>
-
 #include <HDTVocabulary.hpp>
 #include <RDFParser.hpp>
 

--- a/hdt-lib/src/hdt/BasicModifiableHDT.cpp
+++ b/hdt-lib/src/hdt/BasicModifiableHDT.cpp
@@ -4,7 +4,7 @@
  *  Created on: 11/08/2012
  *      Author: mck
  */
-
+#include <stdexcept>
 #include "BasicModifiableHDT.hpp"
 
 #include "TripleIDStringIterator.hpp"

--- a/hdt-lib/src/hdt/ControlInformation.cpp
+++ b/hdt-lib/src/hdt/ControlInformation.cpp
@@ -24,7 +24,7 @@
  *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
  *
  */
-
+#include <stdexcept>
 #include <stdlib.h>
 #include <string.h>
 #include <string>

--- a/hdt-lib/src/hdt/HDTFactory.cpp
+++ b/hdt-lib/src/hdt/HDTFactory.cpp
@@ -24,7 +24,7 @@
  *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
  *
  */
-
+#include <stdexcept>
 #include <HDT.hpp>
 #include <HDTVocabulary.hpp>
 

--- a/hdt-lib/src/header/PlainHeader.cpp
+++ b/hdt-lib/src/header/PlainHeader.cpp
@@ -28,7 +28,7 @@
  *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
  *
  */
-
+#include <stdexcept>
 #include <HDTVocabulary.hpp>
 
 #include "../rdf/RDFParserNtriples.hpp"

--- a/hdt-lib/src/libdcs/CSD.cpp
+++ b/hdt-lib/src/libdcs/CSD.cpp
@@ -30,7 +30,7 @@
  *   Rodrigo Canovas:  rcanovas@dcc.uchile.cl
  *   Miguel A. Martinez-Prieto:  migumar2@infor.uva.es
  */
-
+#include <stdexcept>
 #include "CSD.h"
 #include "CSD_PFC.h"
 

--- a/hdt-lib/src/libdcs/CSD_PFC.cpp
+++ b/hdt-lib/src/libdcs/CSD_PFC.cpp
@@ -24,7 +24,7 @@
  *   Rodrigo Canovas:  rcanovas@dcc.uchile.cl
  *   Miguel A. Martinez-Prieto:  migumar2@infor.uva.es
  */
-
+#include <stdexcept>
 #include <stdlib.h>
 
 #include "../util/crc8.h"

--- a/hdt-lib/src/libdcs/VByte.cpp
+++ b/hdt-lib/src/libdcs/VByte.cpp
@@ -24,7 +24,7 @@
  *   Miguel A. Martinez-Prieto:  migumar2@infor.uva.es
  */
 
-
+#include <stdexcept>
 #include "VByte.h"
 
 namespace csd

--- a/hdt-lib/src/rdf/RDFParserNtriples.cpp
+++ b/hdt-lib/src/rdf/RDFParserNtriples.cpp
@@ -4,7 +4,7 @@
  *  Created on: 05/03/2011
  *      Author: mck
  */
-
+#include <stdexcept>
 #include "RDFParserNtriples.hpp"
 #include "../util/fileUtil.hpp"
 

--- a/hdt-lib/src/rdf/RDFSerializer.cpp
+++ b/hdt-lib/src/rdf/RDFSerializer.cpp
@@ -4,7 +4,7 @@
  *  Created on: 11/07/2011
  *      Author: mck
  */
-
+#include <stdexcept>
 #include "RDFSerializer.hpp"
 #ifdef HAVE_RAPTOR
 #include "RDFSerializerRaptor.hpp"

--- a/hdt-lib/src/rdf/RDFSerializerNTriples.cpp
+++ b/hdt-lib/src/rdf/RDFSerializerNTriples.cpp
@@ -4,7 +4,7 @@
  *  Created on: 05/03/2011
  *      Author: mck
  */
-
+#include <stdexcept>
 #include "RDFSerializerNTriples.hpp"
 
 using namespace std;

--- a/hdt-lib/src/rdf/RDFSerializerRaptor.cpp
+++ b/hdt-lib/src/rdf/RDFSerializerRaptor.cpp
@@ -4,7 +4,7 @@
  *  Created on: 05/03/2011
  *      Author: mck
  */
-
+#include <stdexcept>
 #ifdef HAVE_RAPTOR
 #include "RDFSerializerRaptor.hpp"
 

--- a/hdt-lib/src/sequence/AdjacencyList.cpp
+++ b/hdt-lib/src/sequence/AdjacencyList.cpp
@@ -28,7 +28,7 @@
  *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
  *
  */
-
+#include <stdexcept>
 #include "AdjacencyList.hpp"
 
 namespace hdt {

--- a/hdt-lib/src/sequence/HuffmanSequence.cpp
+++ b/hdt-lib/src/sequence/HuffmanSequence.cpp
@@ -28,7 +28,7 @@
  *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
  *
  */
-
+#include <stdexcept>
 #ifdef HAVE_CDS
 
 #include <HDTVocabulary.hpp>

--- a/hdt-lib/src/sequence/LogSequence2.cpp
+++ b/hdt-lib/src/sequence/LogSequence2.cpp
@@ -28,7 +28,7 @@
  *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
  *
  */
-
+#include <stdexcept>
 #include <iostream>
 #include <limits>
 #include <HDTVocabulary.hpp>

--- a/hdt-lib/src/sequence/WaveletSequence.cpp
+++ b/hdt-lib/src/sequence/WaveletSequence.cpp
@@ -28,7 +28,7 @@
  *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
  *
  */
-
+#include <stdexcept>
 #ifdef HAVE_CDS
 
 #include <HDTVocabulary.hpp>

--- a/hdt-lib/src/sparql/BaseJoinBinding.hpp
+++ b/hdt-lib/src/sparql/BaseJoinBinding.hpp
@@ -4,7 +4,7 @@
  *  Created on: 24/09/2011
  *      Author: mck
  */
-
+#include <stdexcept>
 #ifndef BASEJOINBINDING_HPP_
 #define BASEJOINBINDING_HPP_
 

--- a/hdt-lib/src/sparql/MergeJoinBinding.cpp
+++ b/hdt-lib/src/sparql/MergeJoinBinding.cpp
@@ -4,7 +4,7 @@
  *  Created on: 24/09/2011
  *      Author: mck
  */
-
+#include <stdexcept>
 #include "MergeJoinBinding.hpp"
 
 

--- a/hdt-lib/src/sparql/QueryProcessor.cpp
+++ b/hdt-lib/src/sparql/QueryProcessor.cpp
@@ -4,7 +4,7 @@
  *  Created on: 11/08/2012
  *      Author: mck
  */
-
+#include <stdexcept>
 #include <list>
 
 #include "QueryProcessor.hpp"

--- a/hdt-lib/src/sparql/QueryProcessor.hpp
+++ b/hdt-lib/src/sparql/QueryProcessor.hpp
@@ -4,7 +4,7 @@
  *  Created on: 11/08/2012
  *      Author: mck
  */
-
+#include <stdexcept>
 #ifndef QUERYPROCESSOR_HPP_
 #define QUERYPROCESSOR_HPP_
 

--- a/hdt-lib/src/sparql/TriplePatternBinding.cpp
+++ b/hdt-lib/src/sparql/TriplePatternBinding.cpp
@@ -4,7 +4,7 @@
  *  Created on: 24/09/2011
  *      Author: mck
  */
-
+#include <stdexcept>
 #include "TriplePatternBinding.hpp"
 
 namespace hdt {

--- a/hdt-lib/src/sparql/VarBindingInterface.hpp
+++ b/hdt-lib/src/sparql/VarBindingInterface.hpp
@@ -4,7 +4,7 @@
  *  Created on: 24/09/2011
  *      Author: mck
  */
-
+#include <stdexcept>
 #ifndef VARBINDINGBASE_H_
 #define VARBINDINGBASE_H_
 

--- a/hdt-lib/src/sparql/VarFilterBinding.hpp
+++ b/hdt-lib/src/sparql/VarFilterBinding.hpp
@@ -1,3 +1,4 @@
+#include <stdexcept>
 #ifndef VARFILTERBINDING_HPP
 #define VARFILTERBINDING_HPP
 

--- a/hdt-lib/src/triples/BitmapTriples.cpp
+++ b/hdt-lib/src/triples/BitmapTriples.cpp
@@ -28,7 +28,7 @@
  *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
  *
  */
-
+#include <stdexcept>
 #include "BitmapTriples.hpp"
 
 #include "TripleIterators.hpp"

--- a/hdt-lib/src/triples/BitmapTriplesIterators.cpp
+++ b/hdt-lib/src/triples/BitmapTriplesIterators.cpp
@@ -29,7 +29,7 @@
  *
  */
 
-
+#include <stdexcept>
 #include "BitmapTriples.hpp"
 
 #include "TripleIterators.hpp"

--- a/hdt-lib/src/triples/CompactTriples.cpp
+++ b/hdt-lib/src/triples/CompactTriples.cpp
@@ -28,7 +28,7 @@
  *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
  *
  */
-
+#include <stdexcept>
 #include <HDTVocabulary.hpp>
 
 #include "CompactTriples.hpp"

--- a/hdt-lib/src/triples/PlainTriples.cpp
+++ b/hdt-lib/src/triples/PlainTriples.cpp
@@ -28,7 +28,7 @@
  *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
  *
  */
-
+#include <stdexcept>
 #include <HDTVocabulary.hpp>
 
 #include "PlainTriples.hpp"

--- a/hdt-lib/src/triples/TripleListDisk.cpp
+++ b/hdt-lib/src/triples/TripleListDisk.cpp
@@ -28,7 +28,7 @@
  *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
  *
  */
-
+#include <stdexcept>
 #include <HDTVocabulary.hpp>
 
 #include "TripleListDisk.hpp"

--- a/hdt-lib/src/triples/TripleOrderConvert.cpp
+++ b/hdt-lib/src/triples/TripleOrderConvert.cpp
@@ -28,7 +28,7 @@
  *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
  *
  */
-
+#include <stdexcept>
 #include "TripleOrderConvert.hpp"
 
 namespace hdt {

--- a/hdt-lib/src/triples/TriplesComparator.cpp
+++ b/hdt-lib/src/triples/TriplesComparator.cpp
@@ -28,7 +28,7 @@
  *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
  *
  */
-
+#include <stdexcept>
 #include "TriplesComparator.hpp"
 
 namespace hdt {

--- a/hdt-lib/src/triples/TriplesKyoto.cpp
+++ b/hdt-lib/src/triples/TriplesKyoto.cpp
@@ -28,7 +28,7 @@
  *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
  *
  */
-
+#include <stdexcept>
 #include <HDTVocabulary.hpp>
 #include <unistd.h>
 

--- a/hdt-lib/src/triples/TriplesList.cpp
+++ b/hdt-lib/src/triples/TriplesList.cpp
@@ -28,7 +28,7 @@
  *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
  *
  */
-
+#include <stdexcept>
 #include <HDTVocabulary.hpp>
 
 #include "TriplesList.hpp"

--- a/hdt-lib/src/util/crc32.h
+++ b/hdt-lib/src/util/crc32.h
@@ -15,7 +15,7 @@
  *****************************************************************************/
 #ifndef __CRC32___H__
 #define __CRC32___H__
-
+#include <stdexcept>
 #include <iostream>
 #include <stdlib.h>
 #include <stdint.h>

--- a/hdt-lib/src/util/fileUtil.cpp
+++ b/hdt-lib/src/util/fileUtil.cpp
@@ -26,7 +26,7 @@
  *   Mario Arias:               mario.arias@gmail.com
  *
  */
-
+#include <stdexcept>
 #include <iostream>
 #include <sys/stat.h>
 #include "fileUtil.hpp"

--- a/hdt-lib/src/util/filemap.cpp
+++ b/hdt-lib/src/util/filemap.cpp
@@ -28,7 +28,7 @@
  *   Miguel A. Martinez-Prieto: migumar2@infor.uva.es
  *
  */
-
+#include <stdexcept>
 #include "filemap.h"
 
 #include <inttypes.h>

--- a/hdt-lib/src/util/propertyutil.cpp
+++ b/hdt-lib/src/util/propertyutil.cpp
@@ -3,7 +3,7 @@
 // (c) Paul D. Senzee
 // Senzee 5
 // http://senzee.blogspot.com
-
+#include <stdexcept>
 #include "propertyutil.h"
 
 #include <sstream>

--- a/hdt-lib/src/util/unicode.hpp
+++ b/hdt-lib/src/util/unicode.hpp
@@ -4,7 +4,7 @@
  *  Created on: 17/07/2012
  *      Author: mck
  */
-
+#include <stdexcept>
 #ifndef UNICODE_HPP_
 #define UNICODE_HPP_
 

--- a/hdt-lib/tools/hdtInfo.cpp
+++ b/hdt-lib/tools/hdtInfo.cpp
@@ -35,7 +35,7 @@
 #include "../src/hdt/HDTFactory.hpp"
 
 #include "../src/rdf/RDFSerializerNTriples.hpp"
-
+#include <stdexcept>
 #include <getopt.h>
 #include <string>
 #include <iostream>

--- a/hdt-lib/tools/rdf2hdt.cpp
+++ b/hdt-lib/tools/rdf2hdt.cpp
@@ -31,7 +31,7 @@
 
 #include <HDT.hpp>
 #include <HDTManager.hpp>
-
+#include <stdexcept>
 #include <string>
 #include <iostream>
 #include <fstream>


### PR DESCRIPTION
PR https://github.com/rdfhdt/hdt-cpp/pull/35 was missing some includes. Didn't notice this on my dev environment (g++ 5.3.1), but apparently hdt didn't compile on older g++ versions