### PR TITLE
[ControlInformation] Return default value instead of throwing

### DIFF
--- a/hdt-lib/include/ControlInformation.hpp
+++ b/hdt-lib/include/ControlInformation.hpp
@@ -89,15 +89,13 @@ public:
 
 	/** Get a property of the ControlInformation
 	 * @param key
-	 * @return
-	 * @throws std::out_of_range if the key is not found
+	 * @return the value, or the empty string if the key does not exist
 	 */
 	const std::string& get(const std::string& key) const;
 
 	/** Get a property of the ControlInformation as unsigned int
 	 * @param key
-	 * @return
-	 * @throws std::out_of_range if the key is not found
+	 * @return the value, or 0 if the key does not exist
 	 */
     uint64_t getUint(const std::string& key) const;
 

--- a/hdt-lib/src/hdt/ControlInformation.cpp
+++ b/hdt-lib/src/hdt/ControlInformation.cpp
@@ -35,6 +35,8 @@
 
 using namespace std;
 
+const string EMPTY_STRING = "";
+
 namespace hdt {
 
 ControlInformation::ControlInformation() : type(UNKNOWN_CI) {}
@@ -201,7 +203,8 @@ void ControlInformation::setFormat(const std::string& format) {
 }
 
 const std::string& ControlInformation::get(const std::string& key) const {
-	return map.at(key);
+  std::map<string,string>::const_iterator it = map.find(key);
+  return it == map.end() ? EMPTY_STRING : it->second;
 }
 
 void ControlInformation::set(const std::string& key, const std::string& value) {
@@ -209,7 +212,8 @@ void ControlInformation::set(const std::string& key, const std::string& value) {
 }
 
 uint64_t ControlInformation::getUint(const std::string& key) const {
-    return strtoull(map.at(key).c_str(), NULL, 10);
+  std::map<string,string>::const_iterator it = map.find(key);
+  return it == map.end() ? 0 : strtoull(it->second.c_str(), NULL, 10);
 }
 
 void ControlInformation::setUint(const std::string& key, uint64_t value) {


### PR DESCRIPTION
This pull request fixes a regression introduced in c96fed326b139ef8d8ddbdab836c5ed876b284d4. Some parts of code rely on default return values rather than exceptions. As an example, [his HDT file](http://users.restdesc.org/rgverbor/tmp/hdt/mmlab.hdt) fails with c96fed326b139ef8d8ddbdab836c5ed876b284d4 but works again with this fix.

However, we could wonder what the desired behavior is. One of the failures was `ci.getUint("sizeStrings")` in `FourSectionDictionary::load`. Key `sizeStrings` could not be found, whereas `hdtInfo` clearly gives `162684` as a value. Nonetheless, this fix restores previous behavior.
