### PR TITLE
HDT format identifier uses only HDT version.

### DIFF
--- a/hdt-lib/include/HDTVocabulary.hpp
+++ b/hdt-lib/include/HDTVocabulary.hpp
@@ -39,8 +39,7 @@ namespace hdt {
 namespace HDTVocabulary {
 	// Base
 	const std::string HDT_BASE = "<http://purl.org/HDT/hdt#";
-	const std::string HDT_CONTAINER = HDT_BASE+"HDT" + HDTVersion::get_version_string("-") + ">";
-	const std::string HDT_CONTAINER_BASE = HDT_BASE+"HDTv" + HDT_VERSION;
+	const std::string HDT_CONTAINER = HDT_BASE+"HDTv" + HDT_VERSION + ">";
 	const std::string HDT_HEADER = HDT_BASE+"header";
 	const std::string HDT_DICTIONARY_BASE = HDT_BASE+"dictionary";
 	const std::string HDT_DICTIONARY = HDT_DICTIONARY_BASE+">";

--- a/hdt-lib/src/hdt/BasicHDT.cpp
+++ b/hdt-lib/src/hdt/BasicHDT.cpp
@@ -665,7 +665,7 @@ void BasicHDT::loadHeader(const char *fileName, ProgressListener *listener)
 	controlInformation.load(*input);
 	std::string hdtFormat = controlInformation.getFormat();
 	if(hdtFormat!=HDTVocabulary::HDT_CONTAINER) {
-		throw std::runtime_error("This software cannot open this version of HDT File.");
+		throw std::runtime_error("This software (v" + std::string(HDT_VERSION) + ".x.x) cannot open this version of HDT File (" + hdtFormat + ")");
 	}
 
 	// Load header
@@ -692,8 +692,7 @@ void BasicHDT::loadFromHDT(std::istream & input, ProgressListener *listener)
 	// Load Global ControlInformation.
 	controlInformation.load(input);
 	std::string hdtFormat = controlInformation.getFormat();
-  //if(hdtFormat!=HDTVocabulary::HDT_CONTAINER) {
-  if (hdtFormat.find(HDTVocabulary::HDT_CONTAINER_BASE) == std::string::npos) {
+  if(hdtFormat!=HDTVocabulary::HDT_CONTAINER) {
 		throw std::runtime_error("This software (v" + std::string(HDT_VERSION) + ".x.x) cannot open this version of HDT File (" + hdtFormat + ")");
 	}
 
@@ -779,8 +778,7 @@ size_t BasicHDT::loadMMap(unsigned char *ptr, unsigned char *ptrMax, ProgressLis
     // Load Global ControlInformation
     count+=controlInformation.load(&ptr[count], ptrMax);
     std::string hdtFormat = controlInformation.getFormat();
-    //if(hdtFormat!=HDTVocabulary::HDT_CONTAINER) {
-    if (hdtFormat.find(HDTVocabulary::HDT_CONTAINER_BASE) == std::string::npos) {
+    if(hdtFormat!=HDTVocabulary::HDT_CONTAINER) {
     	throw std::runtime_error("This software (v" + std::string(HDT_VERSION) + ".x.x) cannot open this version of HDT File (" + hdtFormat + ")");
     }
 


### PR DESCRIPTION
**Issue: HDT files produced by the current master cannot be read by other HDT libraries, nor an earlier version of this library, and unnecessarily so.**

Starting with 1e23041648a8092b93d780d67d47003325966e78, HDT files were being written with a format IRI of `http://purl.org/HDT/hdt#HDTv1-1-2` . This unnecessarily breaks compatibility with existing HDT libraries, which expect the version URL to be `http://purl.org/HDT/hdt#HDTv1`. Since the version number indicates `HDT_version.index_version.release`, only the first component matters to the HDT file itself. This commit reverts the version IRI to `http://purl.org/HDT/hdt#HDTv1`, restoring backward compatibility with other HDT libraries. It also reverts the version detection code to simple equality.

Partially reverts 1e23041648a8092b93d780d67d47003325966e78.
Related to #36.
Fixes bug reported in https://github.com/LinkedDataFragments/Client.js/issues/26#issuecomment-264713082.