### PR TITLE
always use LDFLAGS variable when compiling

### DIFF
--- a/hdt-lib/Makefile
+++ b/hdt-lib/Makefile
@@ -98,7 +98,7 @@ tests: libhdt.a $(TESTS)
 
 %.o: %.cpp $(HEADERS) Makefile
 	@echo " [HDT] Compiling $<"
-	@$(CPP) $(INCLUDES) $(FLAGS) $(DEFINES) -c $< -o $@
+	@$(CPP) $(INCLUDES) $(FLAGS) $(DEFINES) $(LDFLAGS) -c $< -o $@
 
 libhdt.a: $(OBJECTS) $(HEADERS)
 	@echo " [HDT] Linking libhdt.a"


### PR DESCRIPTION
I tried to compile hdt-cpp in an environment where I don't have root access and the serd library is not installed. Basically I'm preparing to run hdt-cpp tools under a Travis CI container environment.

So I first installed serd under ~/local, which works fine. But I wasn't able to compile hdt-cpp against that. 
I tried
```
cd hdt-lib
make LDFLAGS='-I/home/myuser/local/include -L/home/myuser/local/lib'
```
but this failed because `$(LDFLAGS)`, though used in many places in the Makefile, is not used in the rule that does most of the compiling. This PR fixes that, making it possible to compile against a non-root-installed libserd.