### PR TITLE
Fix typo.

### DIFF
--- a/libcds-v1.0.12/src/static/sequence/SequenceBuilderWaveletTreeNoptrsS.cpp
+++ b/libcds-v1.0.12/src/static/sequence/SequenceBuilderWaveletTreeNoptrsS.cpp
@@ -38,7 +38,7 @@ namespace cds_static {
         return new WaveletTreeNoptrsS(sequence, len, bsb, am);
     }
     
-    Sequence * SequenceBuilderWaveletTreeNoptrs::build(const Array & seq) {
+    Sequence * SequenceBuilderWaveletTreeNoptrsS::build(const Array & seq) {
         return new WaveletTreeNoptrsS(seq, bsb, am);
     }
 };


### PR DESCRIPTION
SequenceBuilderWaveletTreeNoptrs::build is already defined in SequenceBuilderWaveletTreeNoptrs.cpp.