### PR TITLE
Use cerr stream instead of cout

### DIFF
--- a/hdt-it/hdtoperation.cpp
+++ b/hdt-it/hdtoperation.cpp
@@ -59,7 +59,7 @@ void HDTOperation::execute() {
             // TODO: Detect whether .hdtcache and .hdt.index exist to be more accurate with the progress
 #if 1
             hdt = hdt::HDTManager::mapIndexedHDT(fileName.toAscii(), &iListener);
-#else            
+#else
             hdt = hdt::HDTManager::loadIndexedHDT(fileName.toAscii(), &iListener);
 #endif
             iListener.setRange(70, 100);
@@ -107,11 +107,11 @@ void HDTOperation::execute() {
         }
         emit processFinished(0);
     } catch (char* err) {
-        cout << "Error caught: " << err << endl;
+        cerr << "Error caught: " << err << endl;
         errorMessage = err;
         emit processFinished(1);
     } catch (const char* err) {
-        cout << "Error caught: " << err << endl;
+        cerr << "Error caught: " << err << endl;
         errorMessage = (char *)err;
         emit processFinished(1);
     }
@@ -122,7 +122,7 @@ void HDTOperation::execute() {
 void HDTOperation::notifyProgress(float level, const char *section) {
 #ifdef OPERATION_CANCELABLE
     if(isCancelled) {
-        cout << "Throwing exception to cancel" << endl;
+        cerr << "Throwing exception to cancel" << endl;
         throw (char *)"Cancelled by user";
     }
 #endif
@@ -136,7 +136,7 @@ void HDTOperation::notifyProgress(float task, float level, const char *section)
 {
 #ifdef OPERATION_CANCELABLE
     if(isCancelled) {
-        cout << "Throwing exception to cancel" << endl;
+        cerr << "Throwing exception to cancel" << endl;
         throw (char *)"Cancelled by user";
     }
 #endif
@@ -270,15 +270,12 @@ int HDTOperation::exec()
 
 void HDTOperation::cancel()
 {
-    //cout << "Operation cancelled" << endl;
+    //cerr << "Operation cancelled" << endl;
     isCancelled = true;
 }
 
 void HDTOperation::finished()
 {
-    cout << "Finished! :)" << endl;
+    cerr << "Finished! :)" << endl;
     emit processFinished(0);
 }
-
-
-

--- a/hdt-it/myapplication.cpp
+++ b/hdt-it/myapplication.cpp
@@ -32,14 +32,14 @@ bool MyApplication::notify(QObject *o, QEvent *e)
     try {
         return QApplication::notify(o, e);
     } catch (char *err) {
-        std::cout << "Exception caugth in notify (char *): " << err << endl;
+        std::cerr << "Exception caugth in notify (char *): " << err << endl;
     } catch (const char *err) {
-        std::cout << "Exception caugth in notify (const char *): " << err << endl;
+        std::cerr << "Exception caugth in notify (const char *): " << err << endl;
     } catch (const std::exception& ex) {
-        std::cout << "Exception caugth in notify (std::exception &): " << ex.what() << endl;
+        std::cerr << "Exception caugth in notify (std::exception &): " << ex.what() << endl;
     } catch (const std::string& ex) {
-        std::cout << "Exception caugth in notify (std::string &): " << ex << endl;
+        std::cerr << "Exception caugth in notify (std::string &): " << ex << endl;
     } catch (...) {
-        std::cout << "Unknown Exception caugth in notify: " << endl;
+        std::cerr << "Unknown Exception caugth in notify: " << endl;
     }
 }

--- a/hdt-it/regexmodel.cpp
+++ b/hdt-it/regexmodel.cpp
@@ -79,9 +79,9 @@ QVariant RegexModel::data(const QModelIndex &index, int role) const
             }
 
         } catch (char *e) {
-            cout << "Error accesing dictionary: " << e << endl;
+            cerr << "Error accesing dictionary: " << e << endl;
         } catch (const char *e) {
-            cout << "Error accesing dictionary: " << e << endl;
+            cerr << "Error accesing dictionary: " << e << endl;
         }
         return QVariant();
 

--- a/hdt-it/searchresultsmodel.cpp
+++ b/hdt-it/searchresultsmodel.cpp
@@ -36,7 +36,7 @@ QVariant SearchResultsModel::data(const QModelIndex &index, int role) const
     case Qt::ToolTipRole:
     case Qt::DisplayRole:
     {
-	// cout << "SearchResultsModel.data " << index.row() << "," << index.column() << endl;
+	// cerr << "SearchResultsModel.data " << index.row() << "," << index.column() << endl;
         // Compiler complains that by calling findTriple we are modifying internal
         // state, which is illegal due to this function being const. But we need to
         // modify the currentIndex and currentTriple, so we can avoid it.
@@ -55,9 +55,9 @@ QVariant SearchResultsModel::data(const QModelIndex &index, int role) const
         return stringutils::toQString(d->idToString(currentTriple->getObject(), hdt::OBJECT).c_str());
             }
         } catch (char *e) {
-            cout << "Error accesing dictionary: " << e << endl;
+            cerr << "Error accesing dictionary: " << e << endl;
         } catch (const char *e) {
-            cout << "Error accesing dictionary: " << e << endl;
+            cerr << "Error accesing dictionary: " << e << endl;
         }
         return QVariant();
 
@@ -151,7 +151,7 @@ void SearchResultsModel::findTriple(unsigned int index)
 	goingUp = true;
         currentTriple = triples->next();
         currentIndex = index;
-	//cout << "Jump: " << currentIndex << " => " << *currentTriple << endl;
+	//cerr << "Jump: " << currentIndex << " => " << *currentTriple << endl;
         return;
     }
 
@@ -175,11 +175,5 @@ void SearchResultsModel::findTriple(unsigned int index)
         currentIndex++;
     }
 
-    //cout << "Access " << currentIndex << " => " << *currentTriple << endl;
+    //cerr << "Access " << currentIndex << " => " << *currentTriple << endl;
 }
-
-
-
-
-
-

--- a/hdt-it/triplecomponentmodel.cpp
+++ b/hdt-it/triplecomponentmodel.cpp
@@ -50,14 +50,14 @@ QVariant TripleComponentModel::data(const QModelIndex &index, int role) const
     case Qt::ToolTipRole:
     case Qt::DisplayRole:
     {
-        //cout << "Data: " << index.row() << " role: " << role << " type: " << tripleComponentRole << endl;
+        //cerr << "Data: " << index.row() << " role: " << role << " type: " << tripleComponentRole << endl;
         hdt::Dictionary *d = hdtController->getHDT()->getDictionary();
         try {
         return stringutils::toQString(d->idToString(index.row()+1, tripleComponentRole).c_str());
         } catch (char *e) {
-            cout << "Error accessing dictionary: " << e << endl;
+            cerr << "Error accessing dictionary: " << e << endl;
         } catch (const char *e) {
-            cout << "Error accessing dictionary: " << e << endl;
+            cerr << "Error accessing dictionary: " << e << endl;
         }
         return QVariant();
     }

--- a/hdt-lib/include/HDTListener.hpp
+++ b/hdt-lib/include/HDTListener.hpp
@@ -84,13 +84,13 @@ public:
 	virtual ~StdoutProgressListener() { }
 
     void notifyProgress(float level, const char *section) {
-    	std::cout << "\r " << std::setw( 3 ) << std::setprecision( 5 )<< section << ": " << level << " %                      \r";
-		std::cout.flush();
+    	std::cerr << "\r " << std::setw( 3 ) << std::setprecision( 5 )<< section << ": " << level << " %                      \r";
+		std::cerr.flush();
 	}
 
     void notifyProgress(float task, float level, const char *section) {
-    	std::cout << "\r " << std::setw( 3 ) << std::setprecision( 5 )<< section << ": " << task << " % / " << level << " %                      \r";
-                std::cout.flush();
+    	std::cerr << "\r " << std::setw( 3 ) << std::setprecision( 5 )<< section << ": " << task << " % / " << level << " %                      \r";
+                std::cerr.flush();
         }
 
 };

--- a/hdt-lib/src/dictionary/KyotoDictionary.cpp
+++ b/hdt-lib/src/dictionary/KyotoDictionary.cpp
@@ -220,10 +220,10 @@ void KyotoDictionary::stopProcessing(ProgressListener *listener)
 	while(fetchLeft && fetchRight) {
 		int cmp = subjectStr.compare(objectStr);
 
-		//cout << " Left: "<< subjectStr << endl << "Right: " << objectStr << endl << "Cmp: " << cmp << endl << endl;
+		//cerr << " Left: "<< subjectStr << endl << "Right: " << objectStr << endl << "Cmp: " << cmp << endl << endl;
 
 		if(cmp==0) {
-			//cout << "New shared: " << subjectStr<<endl;
+			//cerr << "New shared: " << subjectStr<<endl;
 			curSubj->remove();
 			curObj->remove();
 			shared.set(subjectStr.c_str(), subjectStr.length(), (const char *)&count, sizeof(count));
@@ -242,9 +242,9 @@ void KyotoDictionary::stopProcessing(ProgressListener *listener)
 		}
 
 	if((iterations%100000)==0) {
-		cout << "Iterations: "<< (iterations/1000) << "K   " << endl;
-			cout << "Subjects " << leftCount << "/" << totalSubjects << endl;
-			cout << "Objects " << rightCount << "/" << totalObjects << endl;
+		cerr << "Iterations: "<< (iterations/1000) << "K   " << endl;
+			cerr << "Subjects " << leftCount << "/" << totalSubjects << endl;
+			cerr << "Objects " << rightCount << "/" << totalObjects << endl;
 		}
 		iterations++;
 	}
@@ -270,7 +270,7 @@ void KyotoDictionary::stopProcessing(ProgressListener *listener)
 		}
 
 		if((count%100000)==0) {
-			cout << "Subjects: "<< (count/1000) << "K / " << (totalSubjects/1000) << "K" << endl;
+			cerr << "Subjects: "<< (count/1000) << "K / " << (totalSubjects/1000) << "K" << endl;
 		}
 		count++;
 	}
@@ -300,7 +300,7 @@ void KyotoDictionary::stopProcessing(ProgressListener *listener)
 	objects.defrag();
 #endif
 
-	dumpSizes(cout);
+	dumpSizes(cerr);
 }
 
 
@@ -492,15 +492,15 @@ void KyotoDictionary::populateHeader(Header &header, string rootNode)
 }
 
 void KyotoDictionary::dumpSizes(ostream &out) {
-	cout << endl;
-	cout << "\n\t [Dictionary stats:\n";
-	cout << "\t   shared subjects-objects:" << getNshared() << "\n";
-	cout << "\t   not shared subjects:" << getNsubjects() - getNshared() << "\n";
-	cout << "\t   not shared objects:" << getNobjects() - getNshared() << "\n";
-	cout << "\t total subjects:" << getNsubjects() << "\n";
-	cout << "\t total objects:" << getNobjects() << "\n";
-	cout << "\t total predicates:" << getNpredicates() << " ]\n\n";
-	cout << endl;
+	cerr << endl;
+	cerr << "\n\t [Dictionary stats:\n";
+	cerr << "\t   shared subjects-objects:" << getNshared() << "\n";
+	cerr << "\t   not shared subjects:" << getNsubjects() - getNshared() << "\n";
+	cerr << "\t   not shared objects:" << getNobjects() - getNshared() << "\n";
+	cerr << "\t total subjects:" << getNsubjects() << "\n";
+	cerr << "\t total objects:" << getNobjects() << "\n";
+	cerr << "\t total predicates:" << getNpredicates() << " ]\n\n";
+	cerr << endl;
 }
 
 

--- a/hdt-lib/src/hdt/BasicHDT.cpp
+++ b/hdt-lib/src/hdt/BasicHDT.cpp
@@ -199,7 +199,7 @@ ModifiableTriples* BasicHDT::getLoadTriples() {
 
 
 void DictionaryLoader::processTriple(hdt::TripleString& triple,	unsigned long long pos) {
-	//cout << "Triple String: " << triple << endl;
+	//cerr << "Triple String: " << triple << endl;
 	dictionary->insert(triple.getSubject(), SUBJECT);
 	dictionary->insert(triple.getPredicate(), PREDICATE);
 	dictionary->insert(triple.getObject(), OBJECT);
@@ -259,7 +259,7 @@ void TriplesLoader::processTriple(hdt::TripleString& triple, unsigned long long 
 		msg << "ERROR: Could not convert triple to IDS! " << endl << triple << endl << ti;
 		throw ParseException(msg.str());
 	}
-	//cout << "TripleID: " << ti << endl;
+	//cerr << "TripleID: " << ti << endl;
 	char str[100];
 	if ((listener != NULL) && (count % 100000) == 0) {
 		sprintf(str, "Generating Triples: %lld K triples processed.", count / 1000);
@@ -311,7 +311,7 @@ void BasicHDT::loadTriples(const char* fileName, const char* baseUri, RDFNotatio
 		iListener.setRange(85, 90);
 		triplesList->removeDuplicates(&iListener);
 	} catch (std::exception& e) {
-		// cout << "Catch exception triples" << e << endl;
+		// cerr << "Catch exception triples" << e << endl;
 		delete triplesList;
 		throw;
 	}
@@ -329,7 +329,7 @@ void BasicHDT::loadTriples(const char* fileName, const char* baseUri, RDFNotatio
 		delete triplesList;
 	}
 
-	//cout << triples->getNumberOfElements() << " triples added in " << st << endl << endl;
+	//cerr << triples->getNumberOfElements() << " triples added in " << st << endl << endl;
 }
 
 void BasicHDT::fillHeader(string& baseUri) {
@@ -400,7 +400,7 @@ void BasicHDT::loadFromRDF(const char *fileName, string baseUri, RDFNotation not
 		fillHeader(baseUri);
 
 	}catch (std::exception& e) {
-		cout << "Catch exception load: " << e.what() << endl;
+		cerr << "Catch exception load: " << e.what() << endl;
 		deleteComponents();
 		createComponents();
 		throw;
@@ -408,7 +408,7 @@ void BasicHDT::loadFromRDF(const char *fileName, string baseUri, RDFNotation not
 }
 
 void BasicHDT::addDictionaryFromHDT(const char *fileName, ModifiableDictionary *dict, ProgressListener *listener) {
-        cout << fileName << endl;
+        cerr << fileName << endl;
         BasicHDT hdt;
         hdt.mapHDT(fileName, listener);
 
@@ -416,7 +416,7 @@ void BasicHDT::addDictionaryFromHDT(const char *fileName, ModifiableDictionary *
 
         char str[100];
 
-        cout << endl << "Load dictionary from " << fileName << endl;
+        cerr << endl << "Load dictionary from " << fileName << endl;
         for(long long int i=0;i<otherDict->getNsubjects();i++) {
                 string a = otherDict->idToString(i+1, SUBJECT);
                 dict->insert(a, SUBJECT);
@@ -496,7 +496,7 @@ void BasicHDT::loadTriplesFromHDTs(const char** fileNames, size_t numFiles, cons
 
 		for(size_t i=0;i<numFiles;i++) {
 			const char *fileName = fileNames[i];
-	        cout << endl << "Load triples from " << fileName << endl;
+	        cerr << endl << "Load triples from " << fileName << endl;
 	        hdt.mapHDT(fileName);
 	        Dictionary *dict = hdt.getDictionary();
 
@@ -578,7 +578,7 @@ void BasicHDT::loadTriplesFromHDTs(const char** fileNames, size_t numFiles, cons
 
 		header->insert("_:statistics", HDTVocabulary::ORIGINAL_SIZE, totalOriginalSize);
 	} catch (std::exception& e) {
-		// cout << "Catch exception triples" << e << endl;
+		// cerr << "Catch exception triples" << e << endl;
 		delete triplesList;
 		throw;
 	}
@@ -596,7 +596,7 @@ void BasicHDT::loadTriplesFromHDTs(const char** fileNames, size_t numFiles, cons
 		delete triplesList;
 	}
 
-	//cout << triples->getNumberOfElements() << " triples added in " << st << endl << endl;
+	//cerr << triples->getNumberOfElements() << " triples added in " << st << endl << endl;
 
 }
 
@@ -620,7 +620,7 @@ void BasicHDT::loadFromSeveralHDT(const char **fileNames, size_t numFiles, strin
 		fillHeader(baseUri);
 
 	}catch (std::exception& e) {
-		// cout << "Catch exception load: " << e << endl;
+		// cerr << "Catch exception load: " << e << endl;
 		deleteComponents();
 		createComponents();
 		throw;
@@ -675,7 +675,7 @@ void BasicHDT::loadHeader(const char *fileName, ProgressListener *listener)
 	header = HDTFactory::readHeader(controlInformation);
 	header->load(*input, controlInformation, &iListener);
     } catch (std::exception& e) {
-        // cout << "Exception loading HDT: " << ex;
+        // cerr << "Exception loading HDT: " << ex;
         deleteComponents();
         createComponents();
         throw;
@@ -717,7 +717,7 @@ void BasicHDT::loadFromHDT(std::istream & input, ProgressListener *listener)
 	triples = HDTFactory::readTriples(controlInformation);
 	triples->load(input, controlInformation, &iListener);
     } catch (std::exception& e) {
-        // cout << "Exception loading HDT: " << ex;
+        // cerr << "Exception loading HDT: " << ex;
         deleteComponents();
         createComponents();
         throw;

--- a/hdt-lib/src/hdt/BasicModifiableHDT.cpp
+++ b/hdt-lib/src/hdt/BasicModifiableHDT.cpp
@@ -66,7 +66,7 @@ IteratorTripleString *BasicModifiableHDT::search(const char *subject, const char
 	TripleID tid;
 	dictionary->tripleStringtoTripleID(ts, tid);
 
-//	cout << "TID: "<< tid.getSubject() << "," << tid.getPredicate() << "," << tid.getObject() << endl;
+//	cerr << "TID: "<< tid.getSubject() << "," << tid.getPredicate() << "," << tid.getObject() << endl;
 
 	IteratorTripleID *iterID = triples->search(tid);
 
@@ -143,15 +143,15 @@ void BasicModifiableHDT::saveToHDT(std::ostream & output, ProgressListener *list
 
 	//header->save(output);
 
-	cout << "Saving dictionary" << endl;
+	cerr << "Saving dictionary" << endl;
 	StopWatch st;
 	dictionary->save(output, controlInformation);
-	cout << "Dictionary saved in " << st << endl;
+	cerr << "Dictionary saved in " << st << endl;
 
-	cout << "Saving triples" << endl;
+	cerr << "Saving triples" << endl;
 	st.reset();
 	triples->save(output, controlInformation);
-	cout << "Triples saved in " << st << endl;
+	cerr << "Triples saved in " << st << endl;
 
 	this->fileName = fileName;
 }

--- a/hdt-lib/src/sequence/AdjacencyList.cpp
+++ b/hdt-lib/src/sequence/AdjacencyList.cpp
@@ -177,16 +177,16 @@ size_t AdjacencyList::getSize() {
 
 void AdjacencyList::dump() {
 	for(unsigned int i=0; i<countListsX() && i<100; i++) {
-		cout << " [";
+		cerr << " [";
 		for(unsigned int j=0; j<countItemsY(i) && i<100; j++) {
-			cout << get(find(i)+j);
+			cerr << get(find(i)+j);
 
 			if(j!=countItemsY(i)-1)
-				cout << ",";
+				cerr << ",";
 		}
-		cout << "] ";
+		cerr << "] ";
 	}
-	cout << endl;
+	cerr << endl;
 
 #if 0
 	cout << "List has " << getSize() << " elements in " << countListsX() << " lists" << endl;

--- a/hdt-lib/src/sparql/JoinAlgorithms.cpp
+++ b/hdt-lib/src/sparql/JoinAlgorithms.cpp
@@ -96,53 +96,53 @@ bool checkComparisons(TripleID &a, TripleID &b, unsigned short conditions) {
 
 void dumpComparisons(unsigned short conditions) {
 	if( (conditions & (1<<0))) {
-		cout << "SUBJA SUBJB" << endl;
+		cerr << "SUBJA SUBJB" << endl;
 	}
 	if( (conditions & (1<<1))) {
-		cout << "SUBJA PREDB" << endl;
+		cerr << "SUBJA PREDB" << endl;
 	}
 	if( (conditions & (1<<2))) {
-		cout << "SUBJA OBJB" << endl;
+		cerr << "SUBJA OBJB" << endl;
 	}
 
 	if( (conditions & (1<<3))) {
-		cout << "PREDA SUBJB" << endl;
+		cerr << "PREDA SUBJB" << endl;
 	}
 	if( (conditions & (1<<4))) {
-		cout << "PREDA PREDB" << endl;
+		cerr << "PREDA PREDB" << endl;
 	}
 	if( (conditions & (1<<5))) {
-		cout << "PREDA OBJB" << endl;
+		cerr << "PREDA OBJB" << endl;
 	}
 
 	if( (conditions & (1<<6))) {
-		cout << "OBJA SUBJB" << endl;
+		cerr << "OBJA SUBJB" << endl;
 	}
 	if( (conditions & (1<<7))) {
-		cout << "OBJA PREDB" << endl;
+		cerr << "OBJA PREDB" << endl;
 	}
 	if( (conditions & (1<<8))) {
-		cout << "OBJA OBJB" << endl;
+		cerr << "OBJA OBJB" << endl;
 	}
 
 	if( (conditions & (1<<9))) {
-		cout << "SUBJA PREDA" << endl;
+		cerr << "SUBJA PREDA" << endl;
 	}
 	if( (conditions & (1<<10))) {
-		cout << "SUBJA OBJA" << endl;
+		cerr << "SUBJA OBJA" << endl;
 	}
 	if( (conditions & (1<<11))) {
-		cout << "PREDA OBJA" << endl;
+		cerr << "PREDA OBJA" << endl;
 	}
 
 	if( (conditions & (1<<12))) {
-		cout << "SUBJB PREDB" << endl;
+		cerr << "SUBJB PREDB" << endl;
 	}
 	if( (conditions & (1<<13))) {
-		cout << "SUBJB OBJB" << endl;
+		cerr << "SUBJB OBJB" << endl;
 	}
 	if( (conditions & (1<<14))) {
-		cout << "PREDB OBJB" << endl;
+		cerr << "PREDB OBJB" << endl;
 	}
 }
 

--- a/hdt-lib/src/sparql/QueryProcessor.hpp
+++ b/hdt-lib/src/sparql/QueryProcessor.hpp
@@ -36,7 +36,7 @@ private:
 				return i;
 			}
 		}
-		cout << "Var name: " << varName << " not found" << endl;
+		cerr << "Var name: " << varName << " not found" << endl;
 		throw std::runtime_error("Var name does not exist");
 	}
 public:

--- a/hdt-lib/src/sparql/VarBindingInterface.hpp
+++ b/hdt-lib/src/sparql/VarBindingInterface.hpp
@@ -50,7 +50,7 @@ public:
 				return i;
 			}
 		}
-		cout << "Var name: " << varName << " not found" << endl;
+		cerr << "Var name: " << varName << " not found" << endl;
 		throw std::runtime_error("Var name does not exist");
 	}
 	virtual const char *getVarName(unsigned int numvar)=0;

--- a/hdt-lib/src/triples/BitmapTriples.cpp
+++ b/hdt-lib/src/triples/BitmapTriples.cpp
@@ -251,7 +251,7 @@ void BitmapTriples::generateIndex(ProgressListener *listener) {
     generateIndexMemory(&iListener);
    	//generateIndexMemoryFast(listener);
 
-	cout << "Index generated in "<< global << endl;
+	cerr << "Index generated in "<< global << endl;
 }
 
 void BitmapTriples::generateIndexMemory(ProgressListener *listener) {
@@ -278,12 +278,12 @@ void BitmapTriples::generateIndexMemory(ProgressListener *listener) {
 
 		NOTIFYCOND3(&iListener, "Counting appearances of objects", i, arrayZ->getNumberOfElements(), 1000000);
 	}
-	cout << "Count Objects in " << st << " Max was: " << maxCount << endl;
+	cerr << "Count Objects in " << st << " Max was: " << maxCount << endl;
 	st.reset();
 
 #if 0
     for(size_t i=0;i<objectCount->getNumberOfElements();i++) {
-		cout << "Object " << (i+1) << " appears " << objectCount->get(i) << " times." << endl;
+		cerr << "Object " << (i+1) << " appears " << objectCount->get(i) << " times." << endl;
 	}
 #endif
 
@@ -300,26 +300,26 @@ void BitmapTriples::generateIndexMemory(ProgressListener *listener) {
 	  bitmapIndex->set(arrayZ->getNumberOfElements()-1, true);
 	delete objectCount;
 	objectCount=NULL;
-	cout << "Bitmap in " << st << endl;
+	cerr << "Bitmap in " << st << endl;
 	st.reset();
 
-    cout << "Bitmap bits: " << bitmapIndex->getNumBits() << " Ones: " << bitmapIndex->countOnes() << endl;
+    cerr << "Bitmap bits: " << bitmapIndex->getNumBits() << " Ones: " << bitmapIndex->countOnes() << endl;
 #if 0
     for(size_t i=0;i<bitmapIndex->getNumBits();i++) {
 		if(bitmapIndex->access(i)){
-			cout << "1";
+			cerr << "1";
 		} else {
-			cout << "0";
+			cerr << "0";
 		}
 	}
-	cout << endl;
+	cerr << endl;
 
 	for(int i=0;i<bitmapIndex->getNumBits();i++) {
 		unsigned int pos = 0;
 		if(i>0) {
 			pos = bitmapIndex->select1(i)+1;
 		}
-		cout << "Object " << (i+1) << " is stored at " << pos << endl;
+		cerr << "Object " << (i+1) << " is stored at " << pos << endl;
 	}
 #endif
 
@@ -360,7 +360,7 @@ void BitmapTriples::generateIndexMemory(ProgressListener *listener) {
 	}
 	delete objectInsertedCount;
 	objectInsertedCount=NULL;
-	cout << "Object references in " << st << endl;
+	cerr << "Object references in " << st << endl;
 	st.reset();
 
 	predCount->reduceBits();
@@ -369,9 +369,9 @@ void BitmapTriples::generateIndexMemory(ProgressListener *listener) {
 
 #if 0
     for(size_t i=0;i<objectArray->getNumberOfElements();i++) {
-		cout << "Position " << (i) << " references " << objectArray->get(i) << " ." << endl;
+		cerr << "Position " << (i) << " references " << objectArray->get(i) << " ." << endl;
 		if(bitmapIndex->access(i)) {
-			cout << endl;
+			cerr << endl;
 		}
 	}
 #endif
@@ -441,7 +441,7 @@ void BitmapTriples::generateIndexMemory(ProgressListener *listener) {
 		NOTIFYCOND3(&iListener, "Sorting object sublists", first, arrayZ->getNumberOfElements(), 10000);
 	} while(object<=bitmapIndex->countOnes());
 
-	cout << "Sort lists in " << st << endl;
+	cerr << "Sort lists in " << st << endl;
 	st.reset();
 
 	// Save Object Index
@@ -454,10 +454,10 @@ void BitmapTriples::generateIndexMemory(ProgressListener *listener) {
 
         size_t cobject = i==0 ? 1 : bitmapIndex->rank1(i-1)+1;
         size_t subject = indexPtr==0 ? 1 : bitmapY->rank1(indexPtr-1)+1;
-		cout << "\tFinal: " << i << " (" << indexPtr << " > " <<  cobject << "-" << pred << "-"<<subject<<")" << endl;
+		cerr << "\tFinal: " << i << " (" << indexPtr << " > " <<  cobject << "-" << pred << "-"<<subject<<")" << endl;
 
         if(bitmapIndex->access(i)) {
-            cout << endl;
+            cerr << endl;
         }
     }
 #endif
@@ -469,8 +469,8 @@ void BitmapTriples::generateIndexFast(ProgressListener *listener) {
 	IntermediateListener iListener(listener);
 	iListener.setRange(0,40);
 
-    cout << "Generate Object Index" << endl;
-    cout << " Gather object lists..." << endl;
+    cerr << "Generate Object Index" << endl;
+    cerr << " Gather object lists..." << endl;
 
 	// For each object, a list of (zpos, predicate)
 	vector<vector<pair<unsigned int, unsigned int> > > index;
@@ -486,7 +486,7 @@ void BitmapTriples::generateIndexFast(ProgressListener *listener) {
 		}
 		unsigned int adjZlist = i>0 ?  bitmapZ->rank1(i-1) : 0;
 
-		//cout << "Item " << i << " in adjlist " << adjZlist << endl;
+		//cerr << "Item " << i << " in adjlist " << adjZlist << endl;
 		unsigned int pred = arrayY->get(adjZlist);
 		maxpred = pred>maxpred ? pred : maxpred;
 
@@ -508,7 +508,7 @@ void BitmapTriples::generateIndexFast(ProgressListener *listener) {
 	}
 	bitmapIndex = new BitSequence375(arrayZ->getNumberOfElements());
 
-    cout << " Serialize object lists..." << endl;
+    cerr << " Serialize object lists..." << endl;
 	iListener.setRange(40, 80);
 	unsigned int pos=0;
 	unsigned int numBits = bits(arrayY->getNumberOfElements());
@@ -552,26 +552,26 @@ void BitmapTriples::generateIndexFast(ProgressListener *listener) {
 
 		unsigned int cobject = i==0 ? 1 : bitmapIndex->rank1(i-1)+1;
 		unsigned int subject = indexPtr==0 ? 1 : bitmapY->rank1(indexPtr-1)+1;
-		cout << "\tFinal: " << i << " (" << indexPtr << " > " <<  cobject << "-" << pred << "-"<<subject<<")" << endl;
+		cerr << "\tFinal: " << i << " (" << indexPtr << " > " <<  cobject << "-" << pred << "-"<<subject<<")" << endl;
 
         if(bitmapIndex->access(i)) {
-            cout << endl;
+            cerr << endl;
         }
     }
 #endif
 
-	cout << "Index generated in " << st << endl;
+	cerr << "Index generated in " << st << endl;
 
-	cout << "Num triples: " << getNumberOfElements() << endl;
-	cout << "Order: " << getOrderStr(order) << endl;
-	cout << "Original triples size: " << size() << endl;
-	cout << "Stream size: " << arrayIndex->size() << " <" << ((unsigned long long)(arrayIndex->size())*100) / size() << "%>"<< endl;
-	cout << "Bitmap Object size: " << bitmapIndex->getSizeBytes() << " <" << ((unsigned long long)(bitmapIndex->getSizeBytes()))*100 / size() << "%>"<< endl;
+	cerr << "Num triples: " << getNumberOfElements() << endl;
+	cerr << "Order: " << getOrderStr(order) << endl;
+	cerr << "Original triples size: " << size() << endl;
+	cerr << "Stream size: " << arrayIndex->size() << " <" << ((unsigned long long)(arrayIndex->size())*100) / size() << "%>"<< endl;
+	cerr << "Bitmap Object size: " << bitmapIndex->getSizeBytes() << " <" << ((unsigned long long)(bitmapIndex->getSizeBytes()))*100 / size() << "%>"<< endl;
 
-    cout << "Total Index size: " << bitmapIndex->getSizeBytes()+arrayIndex->size() << " <" << ((unsigned long long)(bitmapIndex->getSizeBytes()+arrayIndex->size()))*100 / size() << "%>"<< endl;
-    cout << "Total size: " << size()+bitmapIndex->getSizeBytes()+arrayIndex->size() << endl;
+    cerr << "Total Index size: " << bitmapIndex->getSizeBytes()+arrayIndex->size() << " <" << ((unsigned long long)(bitmapIndex->getSizeBytes()+arrayIndex->size()))*100 / size() << "%>"<< endl;
+    cerr << "Total size: " << size()+bitmapIndex->getSizeBytes()+arrayIndex->size() << endl;
 
-	cout << "Number of lists: " << bitmapZ->countOnes() << " Bits: " << bits(bitmapZ->countOnes()) << endl;
+	cerr << "Number of lists: " << bitmapZ->countOnes() << " Bits: " << bits(bitmapZ->countOnes()) << endl;
 }
 
 void BitmapTriples::populateHeader(Header &header, string rootNode) {

--- a/hdt-lib/src/triples/BitmapTriplesIterators.cpp
+++ b/hdt-lib/src/triples/BitmapTriplesIterators.cpp
@@ -53,10 +53,10 @@ BitmapTriplesSearchIterator::BitmapTriplesSearchIterator(BitmapTriples *trip, Tr
     patZ = pattern.getObject();
 
 #if 0
-    cout << "Pattern: " << patX << " " << patY << " " << patZ << endl;
-    cout << "AdjY: " << endl;
+    cerr << "Pattern: " << patX << " " << patY << " " << patZ << endl;
+    cerr << "AdjY: " << endl;
     adjY.dump();
-    cout << "AdjZ: " << endl;
+    cerr << "AdjZ: " << endl;
     adjZ.dump();
 #endif
 
@@ -70,8 +70,8 @@ BitmapTriplesSearchIterator::BitmapTriplesSearchIterator(BitmapTriples *trip, Tr
 
         uint x = adjY.findListIndex(posY)+1;
 
-        cout << "FWD2 posZ: " << mposZ << " posY: " << posY << "\t";
-        cout << "Triple: " << x << ", " << y << ", " << z << endl;
+        cerr << "FWD2 posZ: " << mposZ << " posY: " << posY << "\t";
+        cerr << "Triple: " << x << ", " << y << ", " << z << endl;
     }
 #endif
 
@@ -84,7 +84,7 @@ void BitmapTriplesSearchIterator::updateOutput() {
     // Convert local order to SPO
     returnTriple.setAll(x,y,z);
     swapComponentOrder(&returnTriple, triples->order, SPO);
-    //cout << returnTriple << endl;
+    //cerr << returnTriple << endl;
 }
 
 void BitmapTriplesSearchIterator::findRange()
@@ -127,7 +127,7 @@ void BitmapTriplesSearchIterator::findRange()
         maxZ = adjZ.getSize();
     }
 
-    //cout << "findRange: Y(" << minY <<  ", " << maxY << ") Z(" << minZ <<", " << maxZ << ")" << endl;
+    //cerr << "findRange: Y(" << minY <<  ", " << maxY << ") Z(" << minZ <<", " << maxZ << ")" << endl;
 }
 
 bool BitmapTriplesSearchIterator::hasNext()
@@ -138,9 +138,9 @@ bool BitmapTriplesSearchIterator::hasNext()
 TripleID *BitmapTriplesSearchIterator::next()
 {
 #if 0
-    cout << "FWD posZ: " << posZ << " posY: " << posY << endl;
-    cout << "\tFWD nextZ: " << nextZ << " nextY: " << nextY << endl;
-    cout << "\tTriple: " << x << ", " << y << ", " << z << endl;
+    cerr << "FWD posZ: " << posZ << " posY: " << posY << endl;
+    cerr << "\tFWD nextZ: " << nextZ << " nextY: " << nextY << endl;
+    cerr << "\tTriple: " << x << ", " << y << ", " << z << endl;
 #endif
 
     z = adjZ.get(posZ);
@@ -200,9 +200,9 @@ TripleID *BitmapTriplesSearchIterator::previous()
 #endif
 
 #if 0
-    cout << "BACK posZ: " << posZ << " posY: " << posY << endl;
-    cout << "\tBack nextZ: " << nextZ << " nextY: " << nextY << endl;
-    cout << "\tTriple: " << x << ", " << y << ", " << z << endl;
+    cerr << "BACK posZ: " << posZ << " posY: " << posY << endl;
+    cerr << "\tBack nextZ: " << nextZ << " nextY: " << nextY << endl;
+    cerr << "\tTriple: " << x << ", " << y << ", " << z << endl;
 #endif
 
     updateOutput();
@@ -327,11 +327,11 @@ MiddleWaveletIterator::MiddleWaveletIterator(BitmapTriples *trip, TripleID &pat)
     }
 
 #if 0
-    cout << "AdjY: " << endl;
+    cerr << "AdjY: " << endl;
     adjY.dump();
-    cout << "AdjZ: " << endl;
+    cerr << "AdjZ: " << endl;
     adjZ.dump();
-    cout << "Pattern: " << patX << " " << patY << " " << patZ << endl;
+    cerr << "Pattern: " << patX << " " << patY << " " << patZ << endl;
 #endif
 
     // Find largest position of Z
@@ -357,7 +357,7 @@ bool MiddleWaveletIterator::hasNext()
 
 TripleID *MiddleWaveletIterator::next()
 {
-    //cout << "nextTriple: " << predicateOcurrence << ", " << prevZ << ", " << posZ << ", " << nextZ << endl;
+    //cerr << "nextTriple: " << predicateOcurrence << ", " << prevZ << ", " << posZ << ", " << nextZ << endl;
     if(posZ>nextZ) {
         predicateOcurrence++;
         posY = predicateIndex->getAppearance(patY, predicateOcurrence);
@@ -384,7 +384,7 @@ bool MiddleWaveletIterator::hasPrevious()
 
 TripleID *MiddleWaveletIterator::previous()
 {
-    //cout << "previousTriple: " << predicateOcurrence << ", " << prevZ << ", " << posZ << ", " << nextZ << endl;
+    //cerr << "previousTriple: " << predicateOcurrence << ", " << prevZ << ", " << posZ << ", " << nextZ << endl;
     if(posZ<=prevZ) {
         predicateOcurrence--;
         posY = predicateIndex->getAppearance(patY, predicateOcurrence);
@@ -528,11 +528,11 @@ IteratorY::IteratorY(BitmapTriples *trip, TripleID &pat) :
     }
 
 #if 0
-    cout << "AdjY: " << endl;
+    cerr << "AdjY: " << endl;
     adjY.dump();
-    cout << "AdjZ: " << endl;
+    cerr << "AdjZ: " << endl;
     adjZ.dump();
-    cout << "Pattern: " << patX << " " << patY << " " << patZ << endl;
+    cerr << "Pattern: " << patX << " " << patY << " " << patZ << endl;
 #endif
 
     goToStart();
@@ -661,12 +661,12 @@ ObjectIndexIterator::ObjectIndexIterator(BitmapTriples *trip, TripleID &pat) :
     }
 
 #if 0
-    cout << "Pattern: " << patX << " " << patY << " " << patZ << endl;
-    cout << "AdjY: " << endl;
+    cerr << "Pattern: " << patX << " " << patY << " " << patZ << endl;
+    cerr << "AdjY: " << endl;
     adjY.dump();
-    cout << "AdjZ: " << endl;
+    cerr << "AdjZ: " << endl;
     adjZ.dump();
-    cout << "AdjIndexObjects: " << endl;
+    cerr << "AdjIndexObjects: " << endl;
     adjIndex.dump();
 #endif
 
@@ -765,9 +765,9 @@ void ObjectIndexIterator::calculateRange() {
 
 
     if(patY!=0) {
-        //cout << endl << endl << "binsearch " << patY <<  endl;
+        //cerr << endl << endl << "binsearch " << patY <<  endl;
         while (minIndex <= maxIndex) {
-            //cout << "binSearch range: " << minIndex << ", " << maxIndex << endl;
+            //cerr << "binSearch range: " << minIndex << ", " << maxIndex << endl;
             long long mid = (minIndex + maxIndex) >> 1;
             unsigned int predicate=getY(mid);
 
@@ -777,16 +777,16 @@ void ObjectIndexIterator::calculateRange() {
                 maxIndex = mid - 1;
             } else {
 #if 0
-                cout << "Middle found at " << mid << " => " << predicate << " Y=" << getY(mid) << endl;
-                cout << "At maxIndex: " << maxIndex << " => Y=" << getY(maxIndex) << endl;
-                cout << "At minIndex: " << minIndex << " => Y=" << getY(minIndex) << endl;
+                cerr << "Middle found at " << mid << " => " << predicate << " Y=" << getY(mid) << endl;
+                cerr << "At maxIndex: " << maxIndex << " => Y=" << getY(maxIndex) << endl;
+                cerr << "At minIndex: " << minIndex << " => Y=" << getY(minIndex) << endl;
 
                 // Do Sequential search
                 unsigned int left = mid;
                 while(left>minIndex && predicate==patY) {
                     left--;
                     predicate = getY(left);
-                    cout << "Check left: " << minIndex << "/" << left << "=>" << predicate << " Z=" << adjZ.get(getPosZ(left))<< endl;
+                    cerr << "Check left: " << minIndex << "/" << left << "=>" << predicate << " Z=" << adjZ.get(getPosZ(left))<< endl;
                 }
                 minIndex= predicate==patY ? left : left+1;
 
@@ -795,7 +795,7 @@ void ObjectIndexIterator::calculateRange() {
                 while(right<maxIndex && predicate==patY) {
                     right++;
                     predicate = getY(right);
-                    cout << "Check right: " << right << "/" << maxIndex << "=>" << predicate << " Z=" << adjZ.get(getPosZ(right)) << endl;
+                    cerr << "Check right: " << right << "/" << maxIndex << "=>" << predicate << " Z=" << adjZ.get(getPosZ(right)) << endl;
                 }
                 maxIndex = predicate==patY ? right :  right-1;
 
@@ -835,17 +835,17 @@ void ObjectIndexIterator::calculateRange() {
                 maxIndex = predicate==patY ? pos : pos-1;
 #endif
 
-//                cout << "Left bound" << endl;
+//                cerr << "Left bound" << endl;
 //                for(unsigned int i=minIndex-2; i<=minIndex+2; i++) {
 //                    if(i>=0) {
-//                        cout << "Found: " << i << "=>" << getY(i) << " " << ((i>= minIndex && i<=maxIndex) ? '*': ' ') << " Z=" << adjZ.get(getPosZ(i))<< endl;
+//                        cerr << "Found: " << i << "=>" << getY(i) << " " << ((i>= minIndex && i<=maxIndex) ? '*': ' ') << " Z=" << adjZ.get(getPosZ(i))<< endl;
 //                    }
 //                }
 
-//                cout << "Right bound" << endl;
+//                cerr << "Right bound" << endl;
 //                for(unsigned int i=maxIndex-2; i<=maxIndex+2; i++) {
 //                    if(i>=0) {
-//                        cout << "Found: " << i << "=>" << getY(i) << " " << ((i>= minIndex && i<=maxIndex) ? '*': ' ') << " Z=" << adjZ.get(getPosZ(i))<< endl;
+//                        cerr << "Found: " << i << "=>" << getY(i) << " " << ((i>= minIndex && i<=maxIndex) ? '*': ' ') << " Z=" << adjZ.get(getPosZ(i))<< endl;
 //                    }
 //                }
 

--- a/hdt-lib/src/triples/TripleIterators.cpp
+++ b/hdt-lib/src/triples/TripleIterators.cpp
@@ -206,7 +206,7 @@ TripleID *RandomAccessIterator::get(unsigned int idx)
 		//cout << "NEXT" << endl;
 	}
 	if(currentIdx!=idx) {
-		cout << "ERROR: " << currentIdx << "!=" << idx << " PREV/NEXT: "<< it->hasPrevious() << ", " << it->hasNext() << endl;
+		cerr << "ERROR: " << currentIdx << "!=" << idx << " PREV/NEXT: "<< it->hasPrevious() << ", " << it->hasNext() << endl;
 	}
 
 	return current;
@@ -240,7 +240,3 @@ RandomAccessIterator::RandomAccessIterator(IteratorTripleID *other) :
 
 
 }
-
-
-
-

--- a/hdt-lib/src/triples/predicateindex.cpp
+++ b/hdt-lib/src/triples/predicateindex.cpp
@@ -109,7 +109,7 @@ void PredicateIndexArray::generate(ProgressListener *listener) {
     }
     if(triples->arrayY->getNumberOfElements())
         bitmap->set(triples->arrayY->getNumberOfElements()-1, true);
-    cout << "Predicate Bitmap in " << st << endl;
+    cerr << "Predicate Bitmap in " << st << endl;
     st.reset();
 
     delete predCount;
@@ -137,7 +137,7 @@ void PredicateIndexArray::generate(ProgressListener *listener) {
 
     delete insertArray;
 
-    cout << "Count predicates in " << st << endl;
+    cerr << "Count predicates in " << st << endl;
 }
 
 }

--- a/hdt-lib/src/util/Histogram.h
+++ b/hdt-lib/src/util/Histogram.h
@@ -156,7 +156,7 @@ public:
 		fileName.append(suffix);
 		ofstream outfile;
 
-		cout << "Writing histogram to: " << fileName << endl;
+		cerr << "Writing histogram to: " << fileName << endl;
 
 		outfile.open(fileName.c_str());
 

--- a/hdt-lib/tools/hdt2rdf.cpp
+++ b/hdt-lib/tools/hdt2rdf.cpp
@@ -59,20 +59,20 @@ int main(int argc, char **argv) {
 		switch(c) {
 		case 'f':
 			rdfFormat = optarg;
-			cout << "Format: " << rdfFormat << endl;
+			cerr << "Format: " << rdfFormat << endl;
 			break;
 		case 'V':
-			cout << HDTVersion::get_version_string(".") << endl;
+			cerr << HDTVersion::get_version_string(".") << endl;
 			return 0;
 		default:
-			cout << "ERROR: Unknown option" << endl;
+			cerr << "ERROR: Unknown option" << endl;
 			help();
 			return 1;
 		}
 	}
 
 	if(argc-optind<2) {
-		cout << "ERROR: You must supply an input and output" << endl << endl;
+		cerr << "ERROR: You must supply an input and output" << endl << endl;
 		help();
 		return 1;
 	}
@@ -90,7 +90,7 @@ int main(int argc, char **argv) {
 		} else if(rdfFormat=="rdfxml") {
 			notation = XML;
 		} else {
-			cout << "ERROR: The RDF output format must be one of: (ntriples, n3, turtle, rdfxml, json)" << endl;
+			cerr << "ERROR: The RDF output format must be one of: (ntriples, n3, turtle, rdfxml, json)" << endl;
 			help();
 			return 1;
 		}
@@ -100,13 +100,13 @@ int main(int argc, char **argv) {
 	outputFile = argv[optind+1];
 
 	if(inputFile=="") {
-		cout << "ERROR: You must supply an HDT input file" << endl << endl;
+		cerr << "ERROR: You must supply an HDT input file" << endl << endl;
 		help();
 		return 1;
 	}
 
 	if(outputFile=="") {
-		cout << "ERROR: You must supply an RDF output file" << endl << endl;
+		cerr << "ERROR: You must supply an RDF output file" << endl << endl;
 		help();
 		return 1;
 	}

--- a/hdt-lib/tools/hdtInfo.cpp
+++ b/hdt-lib/tools/hdtInfo.cpp
@@ -71,14 +71,14 @@ int main(int argc, char **argv) {
 			cout << HDTVersion::get_version_string(".") << endl;
 			return 0;
 		default:
-			cout << "ERROR: Unknown option" << endl;
+			cerr << "ERROR: Unknown option" << endl;
 			help();
 			return 1;
 		}
 	}
 
 	if(argc-optind<1) {
-		cout << "ERROR: You must supply an HDT File" << endl << endl;
+		cerr << "ERROR: You must supply an HDT File" << endl << endl;
 		help();
 		return 1;
 	}

--- a/hdt-lib/tools/hdtSearch.cpp
+++ b/hdt-lib/tools/hdtSearch.cpp
@@ -96,7 +96,7 @@ void iterate(HDT *hdt, char *query, ostream &out, bool measure) {
 				out << *ts << endl;
 			numTriples++;
 		}
-		cout << numTriples << " results in " << st << endl;
+		cerr << numTriples << " results in " << st << endl;
 		delete it;
 
 		interruptSignal=0;	// Interrupt caught, enable again.
@@ -129,14 +129,14 @@ int main(int argc, char **argv) {
 			cout << HDTVersion::get_version_string(".") << endl;
 			return 0;
 		default:
-			cout << "ERROR: Unknown option" << endl;
+			cerr << "ERROR: Unknown option" << endl;
 			help();
 			return 1;
 		}
 	}
 
 	if(argc-optind<1) {
-		cout << "ERROR: You must supply an HDT File" << endl << endl;
+		cerr << "ERROR: You must supply an HDT File" << endl << endl;
 		help();
 		return 1;
 	}
@@ -166,22 +166,22 @@ int main(int argc, char **argv) {
 			char line[1024*10];
 
 			signal(SIGINT, &signalHandler);
-			cout << "                                                 \r>> ";
+			cerr << "                                                 \r>> ";
 			while(cin.getline(line, 1024*10)) {
 				if(strcmp(line, "exit")==0|| strcmp(line,"quit")==0) {
 					break;
 				}
 				if(strlen(line)==0 || strcmp(line, "help")==0) {
-					cout << "Please type Triple Search Pattern, using '?' for wildcards. e.g " << endl;
-					cout << "   http://www.somewhere.com/mysubject ? ?" << endl;
-					cout << "Interrupt with Control+C. Type 'exit', 'quit' or Control+D to exit the shell." << endl;
-					cout << ">> ";
+					cerr << "Please type Triple Search Pattern, using '?' for wildcards. e.g " << endl;
+					cerr << "   http://www.somewhere.com/mysubject ? ?" << endl;
+					cerr << "Interrupt with Control+C. Type 'exit', 'quit' or Control+D to exit the shell." << endl;
+					cerr << ">> ";
 					continue;
 				}
 
 				iterate(hdt, line, *out, measure);
 
-				cout << ">> ";
+				cerr << ">> ";
 			}
 		}
 

--- a/libcds-v1.0.12/src/static/suffixtree/LCP.cpp
+++ b/libcds-v1.0.12/src/static/suffixtree/LCP.cpp
@@ -35,7 +35,7 @@ namespace cds_static
 			m = 1+(n-1)/q;
 			plcp = new int[m];	 //space for sampled lcps
 			if(plcp==NULL) {
-				cout << "Failed to allocate memory for plcp." << endl;
+				cerr << "Failed to allocate memory for plcp." << endl;
 				return NULL;
 			}
 			/*initialize samples to -1*/

--- a/libcds-v1.0.12/src/static/suffixtree/LCP_FMN.cpp
+++ b/libcds-v1.0.12/src/static/suffixtree/LCP_FMN.cpp
@@ -36,7 +36,7 @@ namespace cds_static
 		long long nb = 1;
 		nb = (nb*length+W-1)/W;
 		if(nb > MAXINT) {
-			cout << "Memory limit excess (in LCP)" << endl;
+			cerr << "Memory limit excess (in LCP)" << endl;
 			exit(1);
 		}
 		o = new uint[(uint)nb];
@@ -77,7 +77,7 @@ namespace cds_static
 
 	LCP_FMN::LCP_FMN(TextIndex *csa, char *text, size_t n, size_t op_rs) {
 		if(op_rs!=RRR02_HDR && op_rs!=SDARRAY_HDR) {
-			cout << "Error: op_rs must be RRR02_HDR or SDARRAY_HDR\n" << endl;
+			cerr << "Error: op_rs must be RRR02_HDR or SDARRAY_HDR\n" << endl;
 			exit(1);
 		}
 		lcp_type = FMN_RRR_OS;
@@ -102,7 +102,7 @@ namespace cds_static
 	LCP_FMN::LCP_FMN(LCP *lcp, TextIndex *csa, size_t n, size_t op_rs) {
 		uint *O_aux, *Z_aux;
 		if(op_rs!=RRR02_HDR && op_rs!=SDARRAY_HDR) {
-			cout << "Error: op_rs must be RRR02_HDR or SDARRAY_HDR\n" << endl;
+			cerr << "Error: op_rs must be RRR02_HDR or SDARRAY_HDR\n" << endl;
 			exit(1);
 		}
 		lcp_type = FMN_RRR_OS;

--- a/libcds-v1.0.12/src/static/suffixtree/LCP_PhiSpare.cpp
+++ b/libcds-v1.0.12/src/static/suffixtree/LCP_PhiSpare.cpp
@@ -29,7 +29,7 @@ namespace cds_static
 
 	LCP_PhiSpare::LCP_PhiSpare(TextIndex *csa, char *text, size_t _n, int _q) {
 		if(_q > (int)_n) {
-			cout << "Specified q (" << _q << ") greater than string length (" << _n << ")" << endl;
+			cerr << "Specified q (" << _q << ") greater than string length (" << _n << ")" << endl;
 			exit(1);
 		}
 		lcp_type = PHI;
@@ -44,7 +44,7 @@ namespace cds_static
 			m = 1+(_n-1)/_q;
 			plcp = new int[m];	 //space for sampled lcps
 			if(plcp==NULL) {
-				cout << "Failed to allocate memory for plcp." << endl;
+				cerr << "Failed to allocate memory for plcp." << endl;
 				exit(1);
 			}
 			// initialize samples to -1

--- a/libcds-v1.0.12/src/static/suffixtree/LCP_naive.cpp
+++ b/libcds-v1.0.12/src/static/suffixtree/LCP_naive.cpp
@@ -35,7 +35,7 @@ namespace cds_static
 		long long nb = 1;
 		nb = (nb*b*n+W-1)/W;
 		if(nb > MAXINT) {
-			cout << "Memory limit excess (in LCP)" << endl;
+			cerr << "Memory limit excess (in LCP)" << endl;
 			exit(1);
 		}
 		lcp_array = new uint[(size_t)nb];

--- a/libcds-v1.0.12/src/static/suffixtree/NPR_CN.cpp
+++ b/libcds-v1.0.12/src/static/suffixtree/NPR_CN.cpp
@@ -356,7 +356,7 @@ namespace cds_static
 			return next_ret*b + get_field_64(min_pos[0], bits_b, next_ret);
 
 		/*this never happen*/
-		cout << "Error" << endl;
+		cerr << "Error" << endl;
 		return 0;
 	}
 
@@ -418,7 +418,7 @@ namespace cds_static
 			return next_ret*b + get_field_64(min_pos[r+1], bits_b, next_ret);
 		}
 		/*Error if the code reach this return*/
-		//cout << "Error" << endl;
+		//cerr << "Error" << endl;
 		return (size_t)-1;
 	}
 

--- a/libcds-v1.0.12/tutorial/ssa/build_index.cpp
+++ b/libcds-v1.0.12/tutorial/ssa/build_index.cpp
@@ -32,7 +32,7 @@ int main(int argc, char ** argv) {
 
   fstream input(argv[1],ios::in | ios::binary);
   if(!input.is_open()) {
-    cout << "Error opening file: " << argv[1] << endl;
+    cerr << "Error opening file: " << argv[1] << endl;
     return -1;
   }
 
@@ -52,7 +52,7 @@ int main(int argc, char ** argv) {
   _ssa->build_index();
   _ssa->print_stats();
 
-  cout << "Index size: " << _ssa->size() << endl;
+  cerr << "Index size: " << _ssa->size() << endl;
 
   ofstream fp(argv[2]);
   _ssa->save(fp);
@@ -64,4 +64,3 @@ int main(int argc, char ** argv) {
 
   return 0;
 }
-

--- a/libcds-v1.0.12/tutorial/ssa/test_count.cpp
+++ b/libcds-v1.0.12/tutorial/ssa/test_count.cpp
@@ -45,7 +45,7 @@ int main(int argc, char ** argv) {
 
   fstream input(argv[1],ios::in | ios::binary);
   if(!input.is_open()) {
-    cout << "Error opening file: " << argv[1] << endl;
+    cerr << "Error opening file: " << argv[1] << endl;
     return -1;
   }
 
@@ -88,15 +88,15 @@ int main(int argc, char ** argv) {
     uint occ = _ssa->count(pattern,m);
     uint real_occ = brute_check(text,n,pattern,m);
     if(occ!=real_occ) {
-      cout << "Error for pattern " << i+1 << endl;
-      cout << "ssa->count() returned " << occ << endl;
-      cout << "expected value is " << real_occ << endl;
+      cerr << "Error for pattern " << i+1 << endl;
+      cerr << "ssa->count() returned " << occ << endl;
+      cerr << "expected value is " << real_occ << endl;
       break;
     }
     total_occ += occ;
   }
 
-  cout << "Total occ: " << total_occ << endl;
+  cerr << "Total occ: " << total_occ << endl;
 
   delete [] pattern;
   delete _ssa;


### PR DESCRIPTION
Just some work  to switch to error streams instead of output streams. (related to #18)
All cout streams are replace with cerr where the message was a clear error, or diagnostic in nature (i.e., I also use cerr for the progress stream now)
