### PR TITLE
add cmd line return value (1) when error is caught

### DIFF
--- a/hdt-lib/tools/hdt2rdf.cpp
+++ b/hdt-lib/tools/hdt2rdf.cpp
@@ -127,6 +127,7 @@ int main(int argc, char **argv) {
 		delete hdt;
 	} catch (std::exception& e) {
 		cerr << "ERROR: " << e.what() << endl;
+		return 1;
 	}
 
 }

--- a/hdt-lib/tools/hdtInfo.cpp
+++ b/hdt-lib/tools/hdtInfo.cpp
@@ -155,5 +155,6 @@ int main(int argc, char **argv) {
 
 	} catch (std::exception& e) {
 		cerr << "ERROR: " << e.what() << endl;
+		return 1;
 	}
 }

--- a/hdt-lib/tools/hdtSearch.cpp
+++ b/hdt-lib/tools/hdtSearch.cpp
@@ -192,5 +192,6 @@ int main(int argc, char **argv) {
 		delete hdt;
 	} catch (std::exception& e) {
 		cerr << "ERROR: " << e.what() << endl;
+		return 1;
 	}
 }

--- a/hdt-lib/tools/modifyHeader.cpp
+++ b/hdt-lib/tools/modifyHeader.cpp
@@ -127,5 +127,6 @@ int main(int argc, char **argv) {
 		delete hdt;
 	} catch (std::exception& e) {
 		cerr << "ERROR: " << e.what() << endl;
+		return 1;
 	}
 }

--- a/hdt-lib/tools/rdf2hdt.cpp
+++ b/hdt-lib/tools/rdf2hdt.cpp
@@ -181,6 +181,7 @@ int main(int argc, char **argv) {
 		delete hdt;
 	} catch (std::exception& e) {
 		cerr << "ERROR: " << e.what() << endl;
+		return 1;
 	}
 
 }

--- a/hdt-lib/tools/replaceHeader.cpp
+++ b/hdt-lib/tools/replaceHeader.cpp
@@ -62,5 +62,6 @@ int main(int argc, char **argv) {
 		delete hdt;
 	} catch (std::exception& e) {
 		cerr << "ERROR: " << e.what() << endl;
+		return 1;
 	}
 }

--- a/hdt-lib/tools/searchHeader.cpp
+++ b/hdt-lib/tools/searchHeader.cpp
@@ -73,5 +73,6 @@ int main(int argc, char **argv) {
 		delete hdt;
 	} catch (std::exception& e) {
 		cerr << "ERROR: " << e.what() << endl;
+		return 1;
 	}
 }


### PR DESCRIPTION
Error codes of cmd line scripts was practically always 0, even when errors were thrown (such as 'file not found'). 
The scripts now return error code 1 if needed