### PR TITLE
Improve gzip parsing and serd support in general

### DIFF
--- a/hdt-lib/include/Dictionary.hpp
+++ b/hdt-lib/include/Dictionary.hpp
@@ -70,7 +70,7 @@ public:
     * @param role Triple Role (Subject, Predicate, Object) to be fetched.
     * @return ID of the specified String
     */
-    virtual unsigned int stringToId(std::string &str, TripleComponentRole role)=0;
+    virtual unsigned int stringToId(const std::string &str, TripleComponentRole role)=0;
 
     /**
     * Convert a TripleString object to a TripleID, using the dictionary to perform the conversion.
@@ -78,7 +78,7 @@ public:
     * @param tripleString TripleString to be converted.
     * @return resulting TripleID
     */
-    void tripleStringtoTripleID(TripleString &tripleString, TripleID &tid) {
+    void tripleStringtoTripleID(const TripleString &tripleString, TripleID &tid) {
     	tid.setSubject(stringToId(tripleString.getSubject(), SUBJECT));
     	tid.setPredicate(stringToId(tripleString.getPredicate(), PREDICATE));
     	tid.setObject(stringToId(tripleString.getObject(), OBJECT));
@@ -179,7 +179,7 @@ public:
     * @param str
     * @param role
     */
-    virtual unsigned int insert(std::string &str, TripleComponentRole role)=0;
+    virtual unsigned int insert(const std::string &str, TripleComponentRole role)=0;
 
     /**
     * Function to be called before starting inserting entries to the dictionary to perform an initialization.

--- a/hdt-lib/include/RDFParser.hpp
+++ b/hdt-lib/include/RDFParser.hpp
@@ -46,7 +46,7 @@ class RDFCallback {
 public:
 	virtual ~RDFCallback() { }
 
-	virtual void processTriple(TripleString &triple, unsigned long long pos)=0;
+	virtual void processTriple(const TripleString &triple, unsigned long long pos)=0;
 };
 
 class RDFParserCallback {

--- a/hdt-lib/include/SingleTriple.hpp
+++ b/hdt-lib/include/SingleTriple.hpp
@@ -334,7 +334,7 @@ public:
 	 * Get Subject.
 	 * @return
 	 */
-	std::string &getSubject() {
+	const std::string &getSubject() const {
 		return subject;
 	}
 
@@ -356,7 +356,7 @@ public:
 	 * Get Predicate.
 	 * @return
 	 */
-	std::string &getPredicate() {
+	const std::string &getPredicate() const {
 		return predicate;
 	}
 
@@ -372,7 +372,7 @@ public:
 	 * Get Object.
 	 * @return
 	 */
-	std::string &getObject() {
+	const std::string &getObject() const {
 		return object;
 	}
 

--- a/hdt-lib/src/dictionary/FourSectionDictionary.cpp
+++ b/hdt-lib/src/dictionary/FourSectionDictionary.cpp
@@ -100,7 +100,7 @@ std::string FourSectionDictionary::idToString(unsigned int id, TripleComponentRo
 	return string();
 }
 
-unsigned int FourSectionDictionary::stringToId(std::string &key, TripleComponentRole position)
+unsigned int FourSectionDictionary::stringToId(const std::string &key, TripleComponentRole position)
 {
 	unsigned int ret;
 

--- a/hdt-lib/src/dictionary/FourSectionDictionary.hpp
+++ b/hdt-lib/src/dictionary/FourSectionDictionary.hpp
@@ -60,7 +60,7 @@ public:
 	~FourSectionDictionary();
 
 	std::string idToString(unsigned int id, TripleComponentRole position);
-	unsigned int stringToId(std::string &str, TripleComponentRole position);
+	unsigned int stringToId(const std::string &str, TripleComponentRole position);
 
     size_t getNumberOfElements();
 

--- a/hdt-lib/src/dictionary/KyotoDictionary.cpp
+++ b/hdt-lib/src/dictionary/KyotoDictionary.cpp
@@ -98,7 +98,7 @@ std::string KyotoDictionary::idToString(unsigned int id, TripleComponentRole pos
 	throw std::logic_error("Not implemented");
 }
 
-unsigned int KyotoDictionary::stringToId(std::string &key, TripleComponentRole position)
+unsigned int KyotoDictionary::stringToId(const std::string &key, TripleComponentRole position)
 {
 
 	unsigned int ret;
@@ -355,7 +355,7 @@ uint64_t KyotoDictionary::size()
 }
 
 
-unsigned int KyotoDictionary::insert(std::string & str, TripleComponentRole pos)
+unsigned int KyotoDictionary::insert(const std::string & str, TripleComponentRole pos)
 {
 
 	if(str=="") return 0;

--- a/hdt-lib/src/dictionary/KyotoDictionary.hpp
+++ b/hdt-lib/src/dictionary/KyotoDictionary.hpp
@@ -70,7 +70,7 @@ public:
 	~KyotoDictionary();
 
 	std::string idToString(unsigned int id, TripleComponentRole position);
-	unsigned int stringToId(std::string &str, TripleComponentRole position);
+	unsigned int stringToId(const std::string &str, TripleComponentRole position);
 
 	size_t getNumberOfElements();
 
@@ -99,7 +99,7 @@ public:
     IteratorUCharString *getObjects();
     IteratorUCharString *getShared();
 
-	unsigned int insert(std::string &str, TripleComponentRole position);
+	unsigned int insert(const std::string &str, TripleComponentRole position);
 
 	void startProcessing(ProgressListener *listener = NULL);
 	void stopProcessing(ProgressListener *listener = NULL);

--- a/hdt-lib/src/dictionary/LiteralDictionary.cpp
+++ b/hdt-lib/src/dictionary/LiteralDictionary.cpp
@@ -107,7 +107,7 @@ std::string LiteralDictionary::idToString(unsigned int id, TripleComponentRole p
 	return string();
 }
 
-unsigned int LiteralDictionary::stringToId(std::string &key, TripleComponentRole position) {
+unsigned int LiteralDictionary::stringToId(const std::string &key, TripleComponentRole position) {
 	unsigned int ret;
 
 	if (key.length() == 0) {
@@ -556,7 +556,7 @@ void LiteralDictionary::stopProcessing(ProgressListener *listener) {
 
 }
 
-unsigned int LiteralDictionary::insert(std::string & str,
+unsigned int LiteralDictionary::insert(const std::string & str,
 		TripleComponentRole position) {
 	throw std::runtime_error("This dictionary does not support insertions.");
 }

--- a/hdt-lib/src/dictionary/LiteralDictionary.hpp
+++ b/hdt-lib/src/dictionary/LiteralDictionary.hpp
@@ -61,7 +61,7 @@ public:
 	~LiteralDictionary();
 
 	std::string idToString(unsigned int id, TripleComponentRole position);
-	unsigned int stringToId(std::string &str, TripleComponentRole position);
+	unsigned int stringToId(const std::string &str, TripleComponentRole position);
 
 	/** Returns the number of IDs that contain s[1,..len] as a substring. It also
 	 * return in occs the IDs. Otherwise return 0.
@@ -102,7 +102,7 @@ public:
     IteratorUCharString *getObjects();
     IteratorUCharString *getShared();
 
-	unsigned int insert(std::string &str, TripleComponentRole position);
+	unsigned int insert(const std::string &str, TripleComponentRole position);
 
 	void startProcessing(ProgressListener *listener = NULL);
 	void stopProcessing(ProgressListener *listener = NULL);

--- a/hdt-lib/src/dictionary/PlainDictionary.cpp
+++ b/hdt-lib/src/dictionary/PlainDictionary.cpp
@@ -106,7 +106,7 @@ std::string PlainDictionary::idToString(unsigned int id, TripleComponentRole pos
 	return string();
 }
 
-unsigned int PlainDictionary::stringToId(std::string &key, TripleComponentRole position)
+unsigned int PlainDictionary::stringToId(const std::string &key, TripleComponentRole position)
 {
 	DictEntryIt ret;
 
@@ -281,7 +281,7 @@ uint64_t PlainDictionary::size()
 }
 
 
-unsigned int PlainDictionary::insert(std::string & str, TripleComponentRole pos)
+unsigned int PlainDictionary::insert(const std::string & str, TripleComponentRole pos)
 {
 	if(str=="") return 0;
 

--- a/hdt-lib/src/dictionary/PlainDictionary.hpp
+++ b/hdt-lib/src/dictionary/PlainDictionary.hpp
@@ -122,7 +122,7 @@ public:
 	~PlainDictionary();
 
 	std::string idToString(unsigned int id, TripleComponentRole position);
-	unsigned int stringToId(std::string &str, TripleComponentRole position);
+	unsigned int stringToId(const std::string &str, TripleComponentRole position);
 
     size_t getNumberOfElements();
 
@@ -152,7 +152,7 @@ public:
     IteratorUCharString *getShared();
 
 // ModifiableDictionary
-	unsigned int insert(std::string &str, TripleComponentRole position);
+	unsigned int insert(const std::string &str, TripleComponentRole position);
 
 	void startProcessing(ProgressListener *listener = NULL);
 	void stopProcessing(ProgressListener *listener = NULL);

--- a/hdt-lib/src/hdt/BasicHDT.cpp
+++ b/hdt-lib/src/hdt/BasicHDT.cpp
@@ -198,7 +198,7 @@ ModifiableTriples* BasicHDT::getLoadTriples() {
 }
 
 
-void DictionaryLoader::processTriple(hdt::TripleString& triple,	unsigned long long pos) {
+void DictionaryLoader::processTriple(const hdt::TripleString& triple,	unsigned long long pos) {
 	//cerr << "Triple String: " << triple << endl;
 	dictionary->insert(triple.getSubject(), SUBJECT);
 	dictionary->insert(triple.getPredicate(), PREDICATE);
@@ -257,7 +257,7 @@ void BasicHDT::loadDictionary(const char* fileName, const char* baseUri, RDFNota
 	}
 }
 
-void TriplesLoader::processTriple(hdt::TripleString& triple, unsigned long long pos) {
+void TriplesLoader::processTriple(const hdt::TripleString& triple, unsigned long long pos) {
 	TripleID ti;
 	dictionary->tripleStringtoTripleID(triple, ti);
 	if (ti.isValid()) {

--- a/hdt-lib/src/hdt/BasicHDT.hpp
+++ b/hdt-lib/src/hdt/BasicHDT.hpp
@@ -148,7 +148,7 @@ private:
 	unsigned long long count;
 public:
 	DictionaryLoader(ModifiableDictionary *dictionary, ProgressListener *listener) : dictionary(dictionary), listener(listener), count(0) { }
-	void processTriple(TripleString &triple, unsigned long long pos);
+	void processTriple(const TripleString &triple, unsigned long long pos);
 	inline unsigned long long getCount() {
 		return count;
 	}
@@ -163,7 +163,7 @@ private:
 	uint64_t sizeBytes;
 public:
 	TriplesLoader(Dictionary *dictionary, ModifiableTriples *triples, ProgressListener *listener) : dictionary(dictionary), triples(triples), listener(listener), count(0), sizeBytes(0) { }
-	void processTriple(TripleString &triple, unsigned long long pos);
+	void processTriple(const TripleString &triple, unsigned long long pos);
 	uint64_t getSize() {
 		return sizeBytes;
 	}

--- a/hdt-lib/src/rdf/RDFParserSerd.cpp
+++ b/hdt-lib/src/rdf/RDFParserSerd.cpp
@@ -65,9 +65,9 @@ SerdStatus hdtserd_error(void* handle, const SerdError* error) {
    Called whenever the base URI of the serialisation changes.
 */
 SerdStatus hdtserd_basechanged(void* handle, const SerdNode* uri) {
-	RDFParserSerd *raptorParser = reinterpret_cast<RDFParserSerd *>(handle);
+	RDFParserSerd *serdParser = reinterpret_cast<RDFParserSerd *>(handle);
 
-	return serd_env_set_base_uri(raptorParser->env, uri);
+	return serd_env_set_base_uri(serdParser->env, uri);
 }
 
 /**
@@ -76,9 +76,9 @@ SerdStatus hdtserd_basechanged(void* handle, const SerdNode* uri) {
    Called whenever a prefix is defined in the serialisation.
 */
 SerdStatus hdtserd_prefixchanged(void* handle,const SerdNode* name, const SerdNode* uri) {
-	RDFParserSerd *raptorParser = reinterpret_cast<RDFParserSerd *>(handle);
+	RDFParserSerd *serdParser = reinterpret_cast<RDFParserSerd *>(handle);
 
-	return serd_env_set_prefix(raptorParser->env, name, uri);
+	return serd_env_set_prefix(serdParser->env, name, uri);
 }
 
 /**
@@ -95,10 +95,10 @@ SerdStatus hdtserd_process_triple(void*              handle,
                                   const SerdNode*    object_datatype,
                                   const SerdNode*    object_lang) {
 
-	RDFParserSerd *raptorParser = reinterpret_cast<RDFParserSerd *>(handle);
+	RDFParserSerd *serdParser = reinterpret_cast<RDFParserSerd *>(handle);
 
-	TripleString ts( raptorParser->getString(subject), raptorParser->getString(predicate), raptorParser->getStringObject(object, object_datatype, object_lang));
-	raptorParser->callback->processTriple(ts, raptorParser->numByte);
+	TripleString ts(serdParser->getString(subject), serdParser->getString(predicate), serdParser->getStringObject(object, object_datatype, object_lang));
+	serdParser->callback->processTriple(ts, serdParser->numByte);
 
 	return SERD_SUCCESS;
 }

--- a/hdt-lib/src/rdf/RDFParserSerd.cpp
+++ b/hdt-lib/src/rdf/RDFParserSerd.cpp
@@ -103,17 +103,6 @@ SerdStatus hdtserd_process_triple(void*              handle,
 	return SERD_SUCCESS;
 }
 
-/**
-   Sink (callback) for anonymous node end markers.
-
-   This is called to indicate that the anonymous node with the given
-   @c value will no longer be referred to by any future statements
-   (i.e. the anonymous serialisation of the node is finished).
-*/
-SerdStatus hdtserd_end(void* handle, const SerdNode* node) {
-	return SERD_SUCCESS;
-}
-
 #ifdef HAVE_LIBZ
 
 static const size_t SERD_PAGE_SIZE = 4096;
@@ -174,7 +163,7 @@ void RDFParserSerd::doParse(const char *fileName, const char *baseUri, RDFNotati
 		(SerdBaseSink)hdtserd_basechanged,
 		(SerdPrefixSink)hdtserd_prefixchanged,
 		(SerdStatementSink)hdtserd_process_triple,
-		(SerdEndSink)hdtserd_end);
+		NULL);
 
 	serd_reader_set_error_sink(reader, hdtserd_error, NULL);
 

--- a/hdt-lib/src/rdf/RDFParserSerd.cpp
+++ b/hdt-lib/src/rdf/RDFParserSerd.cpp
@@ -8,46 +8,49 @@ namespace hdt {
 
 string RDFParserSerd::getString(const SerdNode *term) {
 	string out;
+	out.reserve(term->n_bytes + 2);
 
 	if(term->type==SERD_URI) {
-		out.append((char *)term->buf);
+		out.append((const char *)term->buf);
 	} else if(term->type==SERD_BLANK) {
 		out.append("_:");
-		out.append((char *)term->buf);
+		out.append((const char *)term->buf);
 	} else if(term->type==SERD_CURIE) {
 		SerdChunk uri_prefix, uri_suffix;
 		if (serd_env_expand(env, term, &uri_prefix, &uri_suffix)) {
 			// ERROR BAD Curie / Prefix
 		}
-		out.append((char *)uri_prefix.buf);
-		out.append((char *)uri_suffix.buf);
+		out.append((const char *)uri_prefix.buf);
+		out.append((const char *)uri_suffix.buf);
 	}
-	//cout << out << endl;
 	return out;
 }
 
-string RDFParserSerd::getStringObject(const SerdNode *term, const SerdNode *dataType, const SerdNode *lang) {
-	string out;
-
+string RDFParserSerd::getStringObject(const SerdNode *term,
+                                      const SerdNode *dataType,
+                                      const SerdNode *lang) {
 	if(term->type!=SERD_LITERAL) {
 		return getString(term);
 	}
 
-	out.append("\"");
-	out.append((char *)term->buf);
+	string out;
+	out.reserve(term->n_bytes + 2 +
+	            (dataType ? dataType->n_bytes + 4 : 0) +
+	            (lang     ? lang->n_bytes + 1     : 0));
+
+	out.push_back('\"');
+	out.append((const char *)term->buf);
+	out.push_back('\"');
 	if(lang!=NULL){
-		out.append("\"@");
-		out.append((char *)lang->buf);
-	} else {
-		out.append("\"");
+		out.push_back('@');
+		out.append((const char *)lang->buf);
 	}
 	if(dataType!=NULL) {
 		out.append("^^<");
-		out.append((char *)dataType->buf);
-		out.append(">");
+		out.append((const char *)dataType->buf);
+		out.push_back('>');
 	}
 
-	//cout << out << endl;
 	return out;
 }
 

--- a/hdt-lib/src/rdf/RDFParserSerd.cpp
+++ b/hdt-lib/src/rdf/RDFParserSerd.cpp
@@ -263,13 +263,13 @@ void RDFParserSerd::doParse(const char *fileName, const char *baseUri, RDFNotati
 
     if(fileUtil::str_ends_with(fileName,".gz")){
 
-// NOTE: Requires serd 0.27.0
+// NOTE: Requires serd 0.27.1
 #ifdef HAVE_LIBZ
 	LibzSerdData libzSerdData;
 	libzSerdData.file = in_fd;
 	libz_init(&libzSerdData);
 
-	serd_reader_read_source(reader, libz_serd_read, libz_serd_error, &libzSerdData, input); 
+	serd_reader_read_source(reader, libz_serd_read, libz_serd_error, &libzSerdData, input, 4096); 
 
 	libz_destroy(&libzSerdData);
 #else

--- a/hdt-lib/src/rdf/RDFParserSerd.cpp
+++ b/hdt-lib/src/rdf/RDFParserSerd.cpp
@@ -206,7 +206,7 @@ void RDFParserSerd::doParse(const char *fileName, const char *baseUri, RDFNotati
 	}
 	gzclose(libzSerdData.file);
 #else
-	cerr << "HDT Library has not been compiled with gzip support." << end;
+	cerr << "HDT Library has not been compiled with gzip support." << endl;
 #endif
 
     } else {

--- a/hdt-lib/src/rdf/RDFParserSerd.cpp
+++ b/hdt-lib/src/rdf/RDFParserSerd.cpp
@@ -100,8 +100,11 @@ SerdStatus hdtserd_process_triple(void*              handle,
 
 	RDFParserSerd *serdParser = reinterpret_cast<RDFParserSerd *>(handle);
 
-	TripleString ts(serdParser->getString(subject), serdParser->getString(predicate), serdParser->getStringObject(object, object_datatype, object_lang));
-	serdParser->callback->processTriple(ts, serdParser->numByte);
+	serdParser->callback->processTriple(
+		TripleString(serdParser->getString(subject),
+		             serdParser->getString(predicate),
+		             serdParser->getStringObject(object, object_datatype, object_lang)),
+		serdParser->numByte);
 
 	return SERD_SUCCESS;
 }

--- a/hdt-lib/src/rdf/RDFParserSerd.cpp
+++ b/hdt-lib/src/rdf/RDFParserSerd.cpp
@@ -54,11 +54,11 @@ string RDFParserSerd::getStringObject(const SerdNode *term, const SerdNode *data
 }
 
 SerdStatus hdtserd_error(void* handle, const SerdError* error) {
-    //RDFParserSerd *raptorParser = reinterpret_cast<RDFParserSerd *>(handle);
-    //raptorParser->error.append("File: "+e->filename+" Line "+e->line+" Col "+e->col+" Parsing Error: "+e->fmt);
-    fprintf(stderr, error->fmt, error->args);
-    throw std::runtime_error("Error parsing input.");
-    return SERD_ERR_BAD_SYNTAX;
+	fprintf(stderr, "error: %s:%u:%u: ",
+	        error->filename, error->line, error->col);
+	vfprintf(stderr, error->fmt, *error->args);
+	throw std::runtime_error("Error parsing input.");
+	return error->status;
 }
 
 /**

--- a/hdt-lib/src/rdf/RDFParserSerd.cpp
+++ b/hdt-lib/src/rdf/RDFParserSerd.cpp
@@ -1,6 +1,4 @@
-
 #ifdef HAVE_SERD
-
 
 #include "../util/fileUtil.hpp"
 #include "RDFParserSerd.hpp"
@@ -9,48 +7,48 @@
 namespace hdt {
 
 string RDFParserSerd::getString(const SerdNode *term) {
-    string out;
+	string out;
 
-    if(term->type==SERD_URI) {
-        out.append((char *)term->buf);
-    } else if(term->type==SERD_BLANK) {
-        out.append("_:");
-        out.append((char *)term->buf);
-    } else if(term->type==SERD_CURIE) {
-        SerdChunk uri_prefix, uri_suffix;
-        if (serd_env_expand(env, term, &uri_prefix, &uri_suffix)) {
-            // ERROR BAD Curie / Prefix
-        }
-        out.append((char *)uri_prefix.buf);
-        out.append((char *)uri_suffix.buf);
-    }
-    //cout << out << endl;
-    return out;
+	if(term->type==SERD_URI) {
+		out.append((char *)term->buf);
+	} else if(term->type==SERD_BLANK) {
+		out.append("_:");
+		out.append((char *)term->buf);
+	} else if(term->type==SERD_CURIE) {
+		SerdChunk uri_prefix, uri_suffix;
+		if (serd_env_expand(env, term, &uri_prefix, &uri_suffix)) {
+			// ERROR BAD Curie / Prefix
+		}
+		out.append((char *)uri_prefix.buf);
+		out.append((char *)uri_suffix.buf);
+	}
+	//cout << out << endl;
+	return out;
 }
 
 string RDFParserSerd::getStringObject(const SerdNode *term, const SerdNode *dataType, const SerdNode *lang) {
-    string out;
+	string out;
 
-    if(term->type!=SERD_LITERAL) {
-        return getString(term);
-    }
+	if(term->type!=SERD_LITERAL) {
+		return getString(term);
+	}
 
-    out.append("\"");
-    out.append((char *)term->buf);
-    if(lang!=NULL){
-        out.append("\"@");
-        out.append((char *)lang->buf);
-    } else {
-        out.append("\"");
-    }
-    if(dataType!=NULL) {
-        out.append("^^<");
-        out.append((char *)dataType->buf);
-        out.append(">");
-    }
+	out.append("\"");
+	out.append((char *)term->buf);
+	if(lang!=NULL){
+		out.append("\"@");
+		out.append((char *)lang->buf);
+	} else {
+		out.append("\"");
+	}
+	if(dataType!=NULL) {
+		out.append("^^<");
+		out.append((char *)dataType->buf);
+		out.append(">");
+	}
 
-    //cout << out << endl;
-    return out;
+	//cout << out << endl;
+	return out;
 }
 
 SerdStatus hdtserd_error(void* handle, const SerdError* error) {
@@ -67,9 +65,9 @@ SerdStatus hdtserd_error(void* handle, const SerdError* error) {
    Called whenever the base URI of the serialisation changes.
 */
 SerdStatus hdtserd_basechanged(void* handle, const SerdNode* uri) {
-    RDFParserSerd *raptorParser = reinterpret_cast<RDFParserSerd *>(handle);
+	RDFParserSerd *raptorParser = reinterpret_cast<RDFParserSerd *>(handle);
 
-    return serd_env_set_base_uri(raptorParser->env, uri);
+	return serd_env_set_base_uri(raptorParser->env, uri);
 }
 
 /**
@@ -78,32 +76,31 @@ SerdStatus hdtserd_basechanged(void* handle, const SerdNode* uri) {
    Called whenever a prefix is defined in the serialisation.
 */
 SerdStatus hdtserd_prefixchanged(void* handle,const SerdNode* name, const SerdNode* uri) {
-    RDFParserSerd *raptorParser = reinterpret_cast<RDFParserSerd *>(handle);
+	RDFParserSerd *raptorParser = reinterpret_cast<RDFParserSerd *>(handle);
 
-    return serd_env_set_prefix(raptorParser->env, name, uri);
+	return serd_env_set_prefix(raptorParser->env, name, uri);
 }
-
 
 /**
    Sink (callback) for statements.
 
    Called for every RDF statement in the serialisation.
 */
-SerdStatus hdtserd_process_triple(void* handle,
-                                        SerdStatementFlags flags,
-                                        const SerdNode*    graph,
-                                        const SerdNode*    subject,
-                                        const SerdNode*    predicate,
-                                        const SerdNode*    object,
-                                        const SerdNode*    object_datatype,
-                                        const SerdNode*    object_lang) {
+SerdStatus hdtserd_process_triple(void*              handle,
+                                  SerdStatementFlags flags,
+                                  const SerdNode*    graph,
+                                  const SerdNode*    subject,
+                                  const SerdNode*    predicate,
+                                  const SerdNode*    object,
+                                  const SerdNode*    object_datatype,
+                                  const SerdNode*    object_lang) {
 
-    RDFParserSerd *raptorParser = reinterpret_cast<RDFParserSerd *>(handle);
+	RDFParserSerd *raptorParser = reinterpret_cast<RDFParserSerd *>(handle);
 
-    TripleString ts( raptorParser->getString(subject), raptorParser->getString(predicate), raptorParser->getStringObject(object, object_datatype, object_lang));
-    raptorParser->callback->processTriple(ts, raptorParser->numByte);
+	TripleString ts( raptorParser->getString(subject), raptorParser->getString(predicate), raptorParser->getStringObject(object, object_datatype, object_lang));
+	raptorParser->callback->processTriple(ts, raptorParser->numByte);
 
-    return SERD_SUCCESS;
+	return SERD_SUCCESS;
 }
 
 /**
@@ -114,7 +111,7 @@ SerdStatus hdtserd_process_triple(void* handle,
    (i.e. the anonymous serialisation of the node is finished).
 */
 SerdStatus hdtserd_end(void* handle, const SerdNode* node) {
-    return SERD_SUCCESS;
+	return SERD_SUCCESS;
 }
 
 #ifdef HAVE_LIBZ
@@ -132,7 +129,7 @@ int libz_serd_error(void *stream) {
 	return d->err;
 }
 
-size_t libz_serd_read(void *buf, size_t size, size_t nmemb, void *stream){
+size_t libz_serd_read(void *buf, size_t size, size_t nmemb, void *stream) {
 	LibzSerdData *d = reinterpret_cast<LibzSerdData *>(stream);
 
 	const int numRead = gzread(d->file, buf, nmemb * size);
@@ -145,84 +142,81 @@ size_t libz_serd_read(void *buf, size_t size, size_t nmemb, void *stream){
 
 #endif
 
-
 RDFParserSerd::RDFParserSerd() : numByte(0)
 {
 }
 
 RDFParserSerd::~RDFParserSerd() {
-
 }
 
-SerdSyntax RDFParserSerd::getParserType(RDFNotation notation){
-    switch(notation){
-    case NTRIPLES:
-        return SERD_NTRIPLES;
-    case TURTLE:
-        return SERD_TURTLE;
-    default:
-        throw ParseException("Serd parser only supports ntriples and turtle.");
-    }
+SerdSyntax RDFParserSerd::getParserType(RDFNotation notation) {
+	switch(notation){
+	case NTRIPLES:
+		return SERD_NTRIPLES;
+	case TURTLE:
+		return SERD_TURTLE;
+	default:
+		throw ParseException("Serd parser only supports ntriples and turtle.");
+	}
 }
 
 void RDFParserSerd::doParse(const char *fileName, const char *baseUri, RDFNotation notation, bool ignoreErrors, RDFCallback *callback) {
+	this->callback = callback;
+	this->numByte = fileUtil::getSize(fileName);
 
-    this->callback = callback;
-    this->numByte = fileUtil::getSize(fileName);
+	// Create Base URI and environment
+	SerdURI  base_uri = SERD_URI_NULL;
+	SerdNode base = serd_node_new_file_uri((const uint8_t *)fileName, NULL, &base_uri, false);
+	env = serd_env_new(&base);
 
-    // Create Base URI and environment
-    SerdURI  base_uri = SERD_URI_NULL;
-    SerdNode base = serd_node_new_file_uri((const uint8_t *)fileName, NULL, &base_uri, false);
-    env = serd_env_new(&base);
+	SerdReader* reader = serd_reader_new(
+		getParserType(notation), this, NULL,
+		(SerdBaseSink)hdtserd_basechanged,
+		(SerdPrefixSink)hdtserd_prefixchanged,
+		(SerdStatementSink)hdtserd_process_triple,
+		(SerdEndSink)hdtserd_end);
 
-    SerdReader* reader = serd_reader_new(
-                getParserType(notation), this, NULL,
-                (SerdBaseSink)hdtserd_basechanged,
-                (SerdPrefixSink)hdtserd_prefixchanged,
-                (SerdStatementSink)hdtserd_process_triple,
-                (SerdEndSink)hdtserd_end);
+	serd_reader_set_error_sink(reader, hdtserd_error, NULL);
 
-    serd_reader_set_error_sink(reader, hdtserd_error, NULL);
+	const uint8_t* input=serd_uri_to_path((const uint8_t *)fileName);
 
-    const uint8_t* input=serd_uri_to_path((const uint8_t *)fileName);
+	if(fileUtil::str_ends_with(fileName,".gz")){
 
-    if(fileUtil::str_ends_with(fileName,".gz")){
-
-// NOTE: Requires serd 0.27.1
+		// NOTE: Requires serd 0.27.1
 #ifdef HAVE_LIBZ
-	LibzSerdData libzSerdData;
-	libzSerdData.err = 0;
-	libzSerdData.file = gzopen(fileName, "rb");
-	if (!libzSerdData.file) {
-		throw ParseException("Could not open input file for parsing");
-	}
+		LibzSerdData libzSerdData;
+		libzSerdData.err = 0;
+		libzSerdData.file = gzopen(fileName, "rb");
+		if (!libzSerdData.file) {
+			throw ParseException("Could not open input file for parsing");
+		}
 
-	gzbuffer(libzSerdData.file, LIBZ_BUFFER_SIZE);
-	const SerdStatus status = serd_reader_read_source(
-		reader, libz_serd_read, libz_serd_error,
-		&libzSerdData, input, SERD_PAGE_SIZE);
-	if (status) {
-		throw ParseException((const char*)serd_strerror(status));
-	}
-	gzclose(libzSerdData.file);
+		gzbuffer(libzSerdData.file, LIBZ_BUFFER_SIZE);
+		const SerdStatus status = serd_reader_read_source(
+			reader, libz_serd_read, libz_serd_error,
+			&libzSerdData, input, SERD_PAGE_SIZE);
+		if (status) {
+			throw ParseException((const char*)serd_strerror(status));
+		}
+		gzclose(libzSerdData.file);
 #else
-	cerr << "HDT Library has not been compiled with gzip support." << endl;
+		cerr << "HDT Library has not been compiled with gzip support." << endl;
 #endif
 
-    } else {
-    FILE *in_fd = fopen((const char*)input, "r");
-    // TODO: fadvise sequential
-    if(in_fd==NULL) {
-        throw ParseException("Could not open input file for parsing");
-    }
-	serd_reader_read_file_handle(reader, in_fd, (const uint8_t *)fileName);
-    fclose(in_fd);
-    }
+	} else {
+		FILE *in_fd = fopen((const char*)input, "r");
+		// TODO: fadvise sequential
+		if(in_fd==NULL) {
+			throw ParseException("Could not open input file for parsing");
+		}
+		serd_reader_read_file_handle(reader, in_fd, (const uint8_t *)fileName);
+		fclose(in_fd);
+	}
 
-    serd_reader_free(reader);
+	serd_reader_free(reader);
 
-    serd_env_free(env);
-    serd_node_free(&base);
+	serd_env_free(env);
+	serd_node_free(&base);
 }
 
 }

--- a/hdt-lib/src/rdf/RDFParserSerd.hpp
+++ b/hdt-lib/src/rdf/RDFParserSerd.hpp
@@ -31,20 +31,21 @@ public:
 
 	void doParse(const char *fileName, const char *baseUri, RDFNotation notation, bool ignoreErrors, RDFCallback *callback);
 
-	friend SerdStatus hdtserd_process_triple(void* handle,
-	                                         SerdStatementFlags flags,
-	                                         const SerdNode*    graph,
-	                                         const SerdNode*    subject,
-	                                         const SerdNode*    predicate,
-	                                         const SerdNode*    object,
-	                                         const SerdNode*    object_datatype,
-	                                         const SerdNode*    object_lang);
+	friend SerdStatus hdtserd_on_statement(void               *handle,
+	                                       SerdStatementFlags  flags,
+	                                       const SerdNode     *graph,
+	                                       const SerdNode     *subject,
+	                                       const SerdNode     *predicate,
+	                                       const SerdNode     *object,
+	                                       const SerdNode     *datatype,
+	                                       const SerdNode     *lang);
 
-	friend SerdStatus hdtserd_prefixchanged(void* handle,const SerdNode* name, const SerdNode* uri);
-	friend SerdStatus hdtserd_basechanged(void* handle, const SerdNode* uri);
-	friend SerdStatus hdtserd_error_sink(void* handle, const SerdError* e);
-	RDFParserSerd();
-	virtual ~RDFParserSerd();
+	friend SerdStatus hdtserd_on_prefix(void           *handle,
+	                                    const SerdNode *name,
+	                                    const SerdNode *uri);
+
+	friend SerdStatus hdtserd_on_base(void *handle, const SerdNode *uri);
+	friend SerdStatus hdtserd_on_error(void *handle, const SerdError *e);
 };
 
 }

--- a/hdt-lib/src/rdf/RDFParserSerd.hpp
+++ b/hdt-lib/src/rdf/RDFParserSerd.hpp
@@ -16,32 +16,35 @@ namespace hdt {
 class RDFParserSerd : public RDFParserCallback {
 
 private:
-    SerdEnv *env;
-    RDFCallback *callback;
-    string error;
-    uint64_t numByte;
+	SerdEnv *env;
+	RDFCallback *callback;
+	string error;
+	uint64_t numByte;
 
-    string getString(const SerdNode *term);
-    string getStringObject(const SerdNode *term, const SerdNode *dataType, const SerdNode *lang);
-    SerdSyntax getParserType(RDFNotation notation);
+	string getString(const SerdNode *term);
+	string getStringObject(const SerdNode *term, const SerdNode *dataType, const SerdNode *lang);
+	SerdSyntax getParserType(RDFNotation notation);
+
 public:
-    RDFParserSerd();
-    virtual ~RDFParserSerd();
+	RDFParserSerd();
+	virtual ~RDFParserSerd();
 
-    void doParse(const char *fileName, const char *baseUri, RDFNotation notation, bool ignoreErrors, RDFCallback *callback);
+	void doParse(const char *fileName, const char *baseUri, RDFNotation notation, bool ignoreErrors, RDFCallback *callback);
 
-    friend SerdStatus hdtserd_process_triple(void* handle,
-                                            SerdStatementFlags flags,
-                                            const SerdNode*    graph,
-                                            const SerdNode*    subject,
-                                            const SerdNode*    predicate,
-                                            const SerdNode*    object,
-                                            const SerdNode*    object_datatype,
-                                            const SerdNode*    object_lang);
+	friend SerdStatus hdtserd_process_triple(void* handle,
+	                                         SerdStatementFlags flags,
+	                                         const SerdNode*    graph,
+	                                         const SerdNode*    subject,
+	                                         const SerdNode*    predicate,
+	                                         const SerdNode*    object,
+	                                         const SerdNode*    object_datatype,
+	                                         const SerdNode*    object_lang);
 
-    friend SerdStatus hdtserd_prefixchanged(void* handle,const SerdNode* name, const SerdNode* uri);
-    friend SerdStatus hdtserd_basechanged(void* handle, const SerdNode* uri);
-    friend SerdStatus hdtserd_error_sink(void* handle, const SerdError* e);
+	friend SerdStatus hdtserd_prefixchanged(void* handle,const SerdNode* name, const SerdNode* uri);
+	friend SerdStatus hdtserd_basechanged(void* handle, const SerdNode* uri);
+	friend SerdStatus hdtserd_error_sink(void* handle, const SerdError* e);
+	RDFParserSerd();
+	virtual ~RDFParserSerd();
 };
 
 }

--- a/hdt-lib/src/rdf/RDFSerializerRaptor.cpp
+++ b/hdt-lib/src/rdf/RDFSerializerRaptor.cpp
@@ -93,7 +93,7 @@ RDFSerializerRaptor::~RDFSerializerRaptor() {
 	raptor_free_world(world);
 }
 
-raptor_term *getTerm(string &str, raptor_world *world) {
+raptor_term *getTerm(const string &str, raptor_world *world) {
 
 	if(str=="") {
 		throw std::runtime_error("Empty Value on triple!");
@@ -118,8 +118,7 @@ raptor_term *getTerm(string &str, raptor_world *world) {
 		// Remove " "
 		return raptor_new_term_from_literal(world, (const unsigned char *)str.substr(1, str.length()-2).c_str(), NULL, NULL);
 	} else if(str.at(0)=='_') {
-		str = str.substr (2);
-		return raptor_new_term_from_blank(world, (const unsigned char *)str.c_str());
+		return raptor_new_term_from_blank(world, (const unsigned char *)str.substr(2).c_str());
 	} else {
 		return raptor_new_term_from_uri_string(world, (const unsigned char *)str.c_str());
 	}

--- a/hdt-lib/src/triples/BitmapTriples.cpp
+++ b/hdt-lib/src/triples/BitmapTriples.cpp
@@ -126,7 +126,7 @@ void BitmapTriples::load(ModifiableTriples &triples, ProgressListener *listener)
 	LogSequence2 *vectorY = new LogSequence2(bits(triples.getNumberOfElements()));
 	LogSequence2 *vectorZ = new LogSequence2(bits(triples.getNumberOfElements()),triples.getNumberOfElements());
 
-	unsigned int lastX, lastY, lastZ;
+	unsigned int lastX=0, lastY=0, lastZ=0;
 	unsigned int x, y, z;
 
 	unsigned int numTriples=0;

--- a/hdt-lib/tests/parse.cpp
+++ b/hdt-lib/tests/parse.cpp
@@ -23,7 +23,7 @@ public:
 		st.reset();
 	}
 
-	void processTriple(TripleString &triple, unsigned long long pos) {
+	void processTriple(const TripleString &triple, unsigned long long pos) {
 		count++;
 		if(count%1000000 == 0) {
 			cout << (count/1000000) << " M triples parsed in " << st << endl;


### PR DESCRIPTION
Uses the simpler gzread API since there are already two buffering mechanisms in play here (in zlib and in serd), and the resulting much simpler code seems to work fine for me.  Tinkering with the zlib buffer size and serd page size might improve performance, but in some quick experiments I can see no difference since parsing does not seem to be the bottleneck.  The default zlib buffer size of 8192 seems to be just as fast, so you may want to save the memory, but I left the previous large buffer value in place.

Numerous other improvements like correct error reporting with file position, slightly reduced overhead, and general clean ups.

Requires https://github.com/drobilla/serd/commit/52d36530ef5bfd1b2be810a1ade6e034b76aa097