### PR TITLE
Allow for e.g., make OFLAGS="-O3 -fPIC" to compile for a shared object.

### DIFF
--- a/hdt-it/README.md
+++ b/hdt-it/README.md
@@ -67,13 +67,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 Visit our Web Page: www.rdfhdt.org
 
 Contacting the authors:
- Mario Arias:               mario.arias@deri.org
- Javier D. Fernandez:       jfergar@infor.uva.es
- Miguel A. Martinez-Prieto: migumar2@infor.uva.es
+ - Mario Arias:               mario.arias@deri.org
+ - Javier D. Fernandez:       jfergar@infor.uva.es
+ - Miguel A. Martinez-Prieto: migumar2@infor.uva.es
  
-
-    $ tools/hdtInfo data/test.hdt > header.nt
-
-Replace the Header of an HDT file with a new one. For example, by editing the existing one as extracted using `hdtInfo`:
-
-    $ tools/replaceHeader data/test.hdt data/testOutput.hdt newHeader.nt

--- a/hdt-it/README.md
+++ b/hdt-it/README.md
@@ -1,0 +1,79 @@
+﻿# HDT-it! GUI tool for the HDT triple format
+
+Overview
+=================
+
+HDT-it is a tool that can generate
+and consume RDF files in HDT format. It demonstrates the capabilities
+of HDT by allowing to search basic triple patterns against HDT files, and
+also visualizes the 3D adjacency matrix of the underlying RDF graph to
+provide an overview of the dataset distribution.
+
+Download executable
+=================
+
+An executable version of the tool is available for multiple platforms in http://www.rdfhdt.org/downloads/ 
+
+Compiling
+=================
+
+Dependencies: 
+
+- HDT-Lib 
+- QT4 (http://doc.qt.io/qt-4.8/)
+	
+Compilation:
+	
+1.Compile the main hdt-lib library. To compile the library run `make` under the directory `hdt-lib`, this will generate the library and tools.
+2. Execute Qmake in libcds-v1.0.12:
+
+    $ cd libcds-v1.0.12/qmake
+    $ qmake 
+    $ make
+    
+3.Execute Qmake in hdt-lib
+
+    $ cd hdt-lib/qmake
+    $ qmake 
+    $ make
+    
+4.Execute Qmake in hdt-it
+
+    $ cd hdt-it
+    $ qmake 
+    $ make
+
+The application should be available in a new hdt-it subfolder (e.g. hdt-it/unix or hdt-it/win32)
+ 
+Licensing
+=================
+Copyright (C) 2012, Mario Arias, Javier D. Fernandez, Miguel A. Martinez-Prieto
+All rights reserved.
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+Visit our Web Page: www.rdfhdt.org
+
+Contacting the authors:
+ Mario Arias:               mario.arias@deri.org
+ Javier D. Fernandez:       jfergar@infor.uva.es
+ Miguel A. Martinez-Prieto: migumar2@infor.uva.es
+ 
+
+    $ tools/hdtInfo data/test.hdt > header.nt
+
+Replace the Header of an HDT file with a new one. For example, by editing the existing one as extracted using `hdtInfo`:
+
+    $ tools/replaceHeader data/test.hdt data/testOutput.hdt newHeader.nt

--- a/hdt-it/hdt-it.pro
+++ b/hdt-it/hdt-it.pro
@@ -101,7 +101,7 @@ INCLUDEPATH += $${LIBCDS}/includes ../hdt-lib/include/ .
 # Using Qt Projects
 #win32:LIBS += ../hdt-lib/qmake/win32/libhdt.a $${LIBCDS}/qmake/win32/libcds.a
 
-win32:LIBS += ../hdt-lib/qmake/win32/hdt.lib $${LIBCDS}/qmake/win32/cds.lib ../../zlib/bin/zlib.lib "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.10586.0\um\x64\opengl32.lib" "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.10586.0\um\x64\glu32.lib" "F:\serd-0.26.0\bin\serd.lib"
+win32:LIBS += ../hdt-lib/qmake/win32/hdt.lib $${LIBCDS}/qmake/win32/cds.lib "F:\git\zlib\bin\zlib.lib" "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.10586.0\um\x64\opengl32.lib" "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.10586.0\um\x64\glu32.lib" "F:\serd-0.26.0\bin\serd.lib"
 
 unix:!macx:LIBS += ../hdt-lib/qmake/unix/libhdt.a $${LIBCDS}/qmake/unix/libcds.a -lGLU
 macx:LIBS += $${LIBCDS}/qmake/macx/libcds.a ../hdt-lib/qmake/macx/libhdt.a
@@ -120,7 +120,7 @@ win32-g++:contains(QMAKE_HOST.arch, x86_64):{
    # win32:LIBS += -L"C:/MinGW/msys/1.0/local/lib/" -lraptor2 -lxml2 -lws2_32
 }
 
-win32:LIBS += -L"C:/msys/local/lib/" -L"/usr/local/lib" -L"C:/MinGW/msys/1.0/local/lib/" -lraptor2 -lxml2 -lws2_32 -lz
+win32:LIBS += -L"C:/msys/local/lib/" -L"/usr/local/lib" -L"C:/MinGW/msys/1.0/local/lib/"
 
 #Unix (Linux & Mac)
 unix:LIBS += -L"/usr/local/lib" -lz -lserd-0

--- a/hdt-it/hdtoperation.cpp
+++ b/hdt-it/hdtoperation.cpp
@@ -11,7 +11,7 @@
 #define USE_DIALOG
 //#define OPERATION_CANCELABLE
 
-#ifdef __WIN32__
+#ifdef WIN32
 #include <windows.h>
 #define sleep(a) Sleep((a)*1000)
 #else

--- a/hdt-lib/Makefile
+++ b/hdt-lib/Makefile
@@ -10,10 +10,12 @@ SERD_SUPPORT=true
 
 CPP=g++
 
+OFLAGS=-O3
+
 ifeq ($(CPP), g++)
-FLAGS=-O3 -Wno-deprecated -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-unused-but-set-variable -Wno-unknown-warning-option -std=gnu++11
+FLAGS=$(OFLAGS) -Wno-deprecated -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-unused-but-set-variable -Wno-unknown-warning-option -std=gnu++11
 else
-FLAGS=-O3 -Wno-deprecated -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-unknown-warning-option
+FLAGS=$(OFLAGS) -Wno-deprecated -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-unknown-warning-option
 endif
 
 INCLUDES=-I $(LIBCDSPATH)/includes/ -I /usr/local/include -I ./include -I /opt/local/include -I /usr/include

--- a/hdt-lib/Makefile
+++ b/hdt-lib/Makefile
@@ -11,7 +11,7 @@ SERD_SUPPORT=true
 CPP=g++
 
 ifeq ($(CPP), g++)
-FLAGS=-O3 -Wno-deprecated -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-unused-but-set-variable -Wno-unknown-warning-option
+FLAGS=-O3 -Wno-deprecated -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-unused-but-set-variable -Wno-unknown-warning-option -std=gnu++11
 else
 FLAGS=-O3 -Wno-deprecated -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-unknown-warning-option
 endif

--- a/hdt-lib/examples/statistics.cpp
+++ b/hdt-lib/examples/statistics.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <sys/stat.h>
 
 #include "../include/Dictionary.hpp"
 #include "../include/HDT.hpp"
@@ -17,15 +18,21 @@ using namespace std;
 using namespace hdt;
 
 void help() {
-	cout << "$ statistics <inputHDTFile>"
+	cout << "$ statistics <inputHDTFile>" << endl;
+	cout
+			<< "Process the input HDT file and generate statistic (by default, in different files in a tmp folder with a prefix inputHDTFile_Statistics)"
+			<< endl << endl;
+	cout
+			<< "\t-o\t<OutputFile>\tGenerate statistics in different files with the prefix <OutputFile>, e.g. output/Dbpedia "
 			<< endl;
 	cout
-			<< "Process the input HDT file and generate statistic (by default, in different files in this folder with a prefix inputHDTFile_Statistics)"
-			<< endl<< endl;
-	cout << "\t-o\t<OutputFile>\tGenerate statistics in different files with the prefix <OutputFile>, e.g. output/Dbpedia "<< endl;
-	cout << "\t-h\t\t\tThis help" << endl<< endl;
-
-	cout<< "Note: The statistics follow the definitions in: Javier D. Fernández, Miguel A. Martínez-Prieto, Pablo de la Fuente Redondo, Claudio Gutiérrez. Characterizing RDF Datasets. Journal of Information Science, accepted for publication, 2016."<<endl;
+			<< "\t-u\t<OutputHDT>\tGenerate statistics and create the outputHDT file including the stats in the header"
+			<< endl;
+	cout << "\t-h\t\t\tThis help" << endl << endl;
+	cout << "\t-a\t\t\tGenerate all statistics (takes longer)" << endl << endl;
+	cout
+			<< "Note: The statistics follow the definitions in: Javier D. Fernández, Miguel A. Martínez-Prieto, Pablo de la Fuente Redondo, Claudio Gutiérrez. Characterizing RDF Datasets. Journal of Information Science, accepted for publication, 2016."
+			<< endl;
 	//cout << "\t-v\tVerbose output" << endl;
 }
 
@@ -35,15 +42,24 @@ int main(int argc, char *argv[]) {
 	int c;
 	string inputFile;
 	string outputFile;
+	bool createHDT = false;
+	string outputFileHDT;
+	bool allStats = false;
 
-	while ((c = getopt(argc, argv, "hi:o:")) != -1) {
+	while ((c = getopt(argc, argv, "hi:o:u:a")) != -1) {
 		switch (c) {
 		case 'h':
 			help();
 			break;
 		case 'o':
 			outputFile = optarg;
-
+			break;
+		case 'u':
+			createHDT = true;
+			outputFileHDT = optarg;
+			break;
+		case 'a':
+			allStats = true;
 			break;
 		default:
 			cout << "ERROR: Unknown option" << endl;
@@ -52,8 +68,6 @@ int main(int argc, char *argv[]) {
 		}
 	}
 
-
-
 	if (argc < 2) {
 		cout << "ERROR: You must supply an input HDT File" << endl << endl;
 		help();
@@ -61,22 +75,26 @@ int main(int argc, char *argv[]) {
 	}
 	inputFile = argv[optind];
 
-		cout<<inputFile<<endl;
+	cout << inputFile << endl;
 
-	if (outputFile == "")
-		outputFile = inputFile;
-
+	if (outputFile == "") {
+		mkdir("tmp", S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+		outputFile = "tmp/" + inputFile;
+		cout << "outputFile:" << outputFile << endl;
+	}
 	// Load HDT file
 	HDT *hdt = HDTManager::mapHDT(inputFile.c_str());
 
 	TriplesList* tl = new TriplesList();
 
 	Triples * trip = hdt->getTriples();
-	cout<<" Number of triples: "<<(unsigned long)(hdt->getTriples()->getNumberOfElements())<<endl;
+	cout << " Number of triples: "
+			<< (unsigned long) (hdt->getTriples()->getNumberOfElements())
+			<< endl;
 	fflush(stdout);
 	IteratorTripleID *it = trip->searchAll();
 	tl->insert(it);
-	cout<<" Number of tripleslist: "<<tl->getNumberOfElements()<<endl;
+	cout << " Number of tripleslist: " << tl->getNumberOfElements() << endl;
 	delete it; // Remember to delete iterator to avoid memory leaks!
 
 	outputFile = outputFile + "_Statistics";
@@ -101,13 +119,14 @@ int main(int argc, char *argv[]) {
 			<< hdt->getDictionary()->getNshared() << endl;
 
 	double ratioSO = (double) hdt->getDictionary()->getNshared()
-							/ (hdt->getDictionary()->getNsubjects()
-									+ hdt->getDictionary()->getNobjects()
-									- hdt->getDictionary()->getNshared());
+			/ (hdt->getDictionary()->getNsubjects()
+					+ hdt->getDictionary()->getNobjects()
+					- hdt->getDictionary()->getNshared());
 	out_summary << "# Ratio Shared Subject-Objects => SO / (S U O) : "
 			<< ratioSO << endl;
 
-	out_header_stats<<vocabSubject<<" <"<<vocabPredicate<<"ratioSharedSO> "<<ratioSO;
+	out_header_stats << vocabSubject << " <" << vocabPredicate
+			<< "ratioSharedSO> " << ratioSO << endl;
 	/*
 	 * Compute over the dictionary to get shared subject-predicate and predicate-object
 	 */
@@ -138,29 +157,33 @@ int main(int argc, char *argv[]) {
 	out_summary << "# Ratio Shared Subject-Predicate => SP / (S U P) : "
 			<< ratioSP << endl;
 
-	out_header_stats<<vocabSubject<<" <"<<vocabPredicate<<"ratioSharedSP> "<<ratioSP;
+	out_header_stats << vocabSubject << " <" << vocabPredicate
+			<< "ratioSharedSP> " << ratioSP << endl;
 
-	double ratioPO =(double) numPredicatesObjects
+	double ratioPO = (double) numPredicatesObjects
 			/ (hdt->getDictionary()->getNobjects()
 					+ hdt->getDictionary()->getNpredicates()
 					- numPredicatesObjects);
 	out_summary << "# Ratio Shared Predicate-Object => PO / (P U O) : "
 			<< ratioPO << endl;
 
-	out_header_stats<<vocabSubject<<" <"<<vocabPredicate<<"ratioSharedPO> "<<ratioPO;
+	out_header_stats << vocabSubject << " <" << vocabPredicate
+			<< "ratioSharedPO> " << ratioPO << endl;
 
 	out_summary.close();
 	out_header_stats.close();
 
 	//erase summary file SO and Type content
-	ofstream out_summarySO;
-	out_summarySO.open((outputFile + "_SO_Summary").c_str(), ios::trunc);
-	out_summarySO.close();
+	if (allStats) {
+		ofstream out_summarySO;
+		out_summarySO.open((outputFile + "_SO_Summary").c_str(), ios::trunc);
+		out_summarySO.close();
 
-	ofstream out_summaryType;
-	out_summaryType.open((outputFile + "_Typed_Summary").c_str(), ios::trunc);
-	out_summaryType.close();
-
+		ofstream out_summaryType;
+		out_summaryType.open((outputFile + "_Typed_Summary").c_str(),
+				ios::trunc);
+		out_summaryType.close();
+	}
 	//find rdf:type
 	unsigned int IDrdftype = 0;
 	string rdftype = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
@@ -184,9 +207,21 @@ int main(int argc, char *argv[]) {
 	}
 
 	tl->calculateDegrees(outputFile, hdt->getDictionary()->getNshared(),
-			IDrdftype);
+			hdt->getDictionary()->getNpredicates(), IDrdftype, allStats);
 
-
+	if (createHDT == true) {
+		// Replace header
+		Header *head = hdt->getHeader();
+		string line;
+		std::ifstream infile((outputFile + "_HeaderStats").c_str());
+		while (getline(infile, line)) {
+			TripleString ti;
+			ti.read(line);
+			head->insert(ti);
+		}
+		// SAVE
+		hdt->saveToHDT(outputFileHDT.c_str());
+	}
 
 	delete hdt;
 }

--- a/hdt-lib/src/dictionary/KyotoDictionary.cpp
+++ b/hdt-lib/src/dictionary/KyotoDictionary.cpp
@@ -30,7 +30,10 @@
  */
 
 #include <sstream>
+
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #include <stdexcept>
 #include "KyotoDictionary.hpp"
 

--- a/hdt-lib/src/dictionary/PlainDictionary.hpp
+++ b/hdt-lib/src/dictionary/PlainDictionary.hpp
@@ -89,10 +89,11 @@ typedef sparse_hash_map<const char *, DictionaryEntry *, hash<const char *>, str
 #else
 
 #ifdef WIN32
-typedef std::hash_map<const char *, DictionaryEntry *, hash<const char *>, str_cmp> DictEntryHash;
+/*typedef std::hash_map<const char *, DictionaryEntry *, hash<const char *>, str_cmp> DictEntryHash;*/
+typedef unordered_map<const char *, DictionaryEntry *, hash<const char *>, str_cmp> DictEntryHash;
 #else
 typedef std::hash_map<const char *, DictionaryEntry *, __gnu_cxx::hash<const char *>, str_cmp> DictEntryHash;
-//typedef unordered_map<const char *, DictionaryEntry *, hash<const char *>, str_cmp> DictEntryHash;
+
 #endif
 #endif
 

--- a/hdt-lib/src/libdcs/CSD_FMIndex.cpp
+++ b/hdt-lib/src/libdcs/CSD_FMIndex.cpp
@@ -39,6 +39,7 @@
 #include <string.h>
 #include <sstream>
 #include <vector>
+#include <functional>
 
 namespace csd {
 
@@ -291,7 +292,7 @@ struct char_array_buffer : public std::streambuf {
 public:
 	char_array_buffer(const char *begin, const char *end) :
 		begin_(begin), end_(end), current_(begin_) {
-		assert(std::less_equal<const char *>()(begin_, end_));
+        assert(less_equal<const char *>()(begin_, end_));
 	};
 
 private:

--- a/hdt-lib/src/rdf/RDFParserSerd.hpp
+++ b/hdt-lib/src/rdf/RDFParserSerd.hpp
@@ -5,7 +5,7 @@
 
 #include <stdint.h>
 
-#include <serd.h>
+#include <serd-0/serd/serd.h>
 
 #include <HDTEnums.hpp>
 

--- a/hdt-lib/src/triples/BitmapTriplesIterators.cpp
+++ b/hdt-lib/src/triples/BitmapTriplesIterators.cpp
@@ -248,10 +248,10 @@ bool BitmapTriplesSearchIterator::canGoTo() {
 }
 
 void BitmapTriplesSearchIterator::goTo(unsigned int pos) {
-	if ((posZ + pos) >= maxZ) {
+    if ((pos) >= maxZ) {
 			throw std::runtime_error("Cannot goTo on this pattern.");
 	}
-	posZ += pos; // move the position of Z
+    posZ = pos; // move the position of Z
 	goToY(); // go to the correct Y
 }
 

--- a/hdt-lib/src/triples/TriplesKyoto.cpp
+++ b/hdt-lib/src/triples/TriplesKyoto.cpp
@@ -30,7 +30,10 @@
  */
 #include <stdexcept>
 #include <HDTVocabulary.hpp>
+
+#ifndef WIN32
 #include <unistd.h>
+#endif
 
 #include "TriplesKyoto.hpp"
 #include "TriplesComparator.hpp"

--- a/hdt-lib/src/triples/TriplesList.cpp
+++ b/hdt-lib/src/triples/TriplesList.cpp
@@ -401,7 +401,12 @@ void TriplesList::calculateDegree(string path, unsigned int maxSO) {
 
 					//register the number of lists per predicate
 					if (listsofPredicates[listPredicates] == 0) {
+#ifdef WIN32
+                        char *copylist = new char[listPredicates.size()+1];
+#else
 						char copylist[listPredicates.size()+1];
+#endif
+                        
 						//listPredicates.copy((char*) copylist.c_str(),
 						listPredicates.copy(copylist,
 								listPredicates.size(), 0);
@@ -413,7 +418,9 @@ void TriplesList::calculateDegree(string path, unsigned int maxSO) {
 									predicateinlists[atoi(part)] + 1;
 							part = strtok(NULL, "+");
 						}
-
+#ifdef WIN32
+						delete copylist;
+#endif
 					}
 					// register the number of repetitions per lists
 					listsofPredicates[listPredicates] =
@@ -468,10 +475,14 @@ void TriplesList::calculateDegree(string path, unsigned int maxSO) {
 		if (order == SPO) {
 			//register the number of lists per predicate
 			if (listsofPredicates[listPredicates] == 0) {
-				char copylist[listPredicates.size()+1];
-                                //listPredicates.copy((char*) copylist.c_str(),
-                                 listPredicates.copy(copylist,listPredicates.size(), 0);
-                                 copylist[listPredicates.size()]='\0';
+#ifdef WIN32
+                char *copylist=new char[listPredicates.size()+1];
+#else
+                char copylist[listPredicates.size()+1];
+#endif
+                //listPredicates.copy((char*) copylist.c_str(),
+                 listPredicates.copy(copylist,listPredicates.size(), 0);
+                 copylist[listPredicates.size()]='\0';
 
 				char *part = strtok(copylist, "+"); // passing a string starts a new iteration
 				while (part) {
@@ -479,7 +490,9 @@ void TriplesList::calculateDegree(string path, unsigned int maxSO) {
 							+ 1;
 					part = strtok(NULL, "+");
 				}
-
+#ifdef WIN32
+                delete copylist;
+#endif
 			}
 			// register the number of repetitions per lists
 			listsofPredicates[listPredicates] =
@@ -741,7 +754,11 @@ void TriplesList::calculateDegreeType(string path, unsigned int rdftypeID) {
 
 				//register the number of lists per predicate
 				if (listsofPredicates[listPredicates] == 0) {
+#ifdef WIN32
+                    char *copylist = new char[listPredicates.size()+1];
+#else
 					char copylist[listPredicates.size()+1];
+#endif
                                         listPredicates.copy(copylist,listPredicates.size(), 0);
                                         copylist[listPredicates.size()]='\0';
 
@@ -752,7 +769,9 @@ void TriplesList::calculateDegreeType(string path, unsigned int rdftypeID) {
 								part)] + 1;
 						part = strtok(NULL, "+");
 					}
-
+#ifdef WIN32
+                    delete copylist;
+#endif
 				}
 				// register the number of repetitions per lists
 				listsofPredicates[listPredicates] =
@@ -843,7 +862,11 @@ void TriplesList::calculateDegreeType(string path, unsigned int rdftypeID) {
 	if (istypedSubject) {
 		//register the number of lists per predicate
 		if (listsofPredicates[listPredicates] == 0) {
+#ifdef WIN32
+            char *copylist = new char[listPredicates.size()+1];
+#else
 			char copylist[listPredicates.size()+1];
+#endif
                         listPredicates.copy(copylist,listPredicates.size(), 0);
                         copylist[listPredicates.size()]='\0';
 
@@ -853,7 +876,9 @@ void TriplesList::calculateDegreeType(string path, unsigned int rdftypeID) {
 				predicateinlists[atoi(part)] = predicateinlists[atoi(part)] + 1;
 				part = strtok(NULL, "+");
 			}
-
+#ifdef WIN32
+            delete copylist;
+#endif
 		}
 		// register the number of repetitions per lists
 		listsofPredicates[listPredicates] = listsofPredicates[listPredicates]

--- a/hdt-lib/src/triples/TriplesList.hpp
+++ b/hdt-lib/src/triples/TriplesList.hpp
@@ -172,9 +172,10 @@ public:
 	 */
 	void setOrder(TripleComponentOrder order);
 
-	 void calculateDegree(string path,unsigned int maxID=0);
+	 void calculateDegree(string path, unsigned int numPredicates,unsigned int maxID=0);
+	 void calculateMinStats(string path, unsigned int numPredicates);
 	 void calculateDegreeType(string path, unsigned int rdftypeID);
-     void calculateDegrees(string path,unsigned int maxID=0,unsigned int rdftypeID=0);
+     void calculateDegrees(string path,unsigned int maxSOID=0,unsigned int numPredicates=0,unsigned int rdftypeID=0,bool allStats=false);
 
 	// Others
 

--- a/hdt-lib/src/util/Histogram.h
+++ b/hdt-lib/src/util/Histogram.h
@@ -25,6 +25,13 @@ public:
 	 * @param End Description of the param.
 	 * @param nBins Description of the param.
 	 */
+
+	Histogram() :
+			Start(0), nBins_by_interval(0), nBins(0),
+					freq(new unsigned int[0]) {
+			reset();
+		}
+
 	Histogram(const double& Start, const double& End, const unsigned int& nBins) :
 		Start(Start), nBins_by_interval(nBins / (End - Start)), nBins(nBins),
 				freq(new unsigned int[nBins]) {
@@ -116,6 +123,7 @@ public:
 	 * @return void
 	 */
 	void end() {
+
 		mean = mean / number;
 		deviation = deviation / number - mean * mean;
 		deviation = sqrt(deviation);

--- a/hdt-lib/src/util/lrucache.hpp
+++ b/hdt-lib/src/util/lrucache.hpp
@@ -1,0 +1,72 @@
+/* 
+ * File:   lrucache.hpp
+ * Author: Alexander Ponomarev
+ *
+ * Created on June 20, 2013, 5:09 PM
+ */
+
+#ifndef _LRUCACHE_HPP_INCLUDED_
+#define	_LRUCACHE_HPP_INCLUDED_
+
+#include <unordered_map>
+#include <list>
+#include <cstddef>
+#include <stdexcept>
+
+namespace cache {
+
+template<typename key_t, typename value_t>
+class lru_cache {
+public:
+	typedef typename std::pair<key_t, value_t> key_value_pair_t;
+	typedef typename std::list<key_value_pair_t>::iterator list_iterator_t;
+
+	lru_cache(size_t max_size) :
+		_max_size(max_size) {
+	}
+	
+	void put(const key_t& key, const value_t& value) {
+		auto it = _cache_items_map.find(key);
+		_cache_items_list.push_front(key_value_pair_t(key, value));
+		if (it != _cache_items_map.end()) {
+			_cache_items_list.erase(it->second);
+			_cache_items_map.erase(it);
+		}
+		_cache_items_map[key] = _cache_items_list.begin();
+		
+		if (_cache_items_map.size() > _max_size) {
+			auto last = _cache_items_list.end();
+			last--;
+			_cache_items_map.erase(last->first);
+			_cache_items_list.pop_back();
+		}
+	}
+	
+	const value_t& get(const key_t& key) {
+		auto it = _cache_items_map.find(key);
+		if (it == _cache_items_map.end()) {
+			throw std::range_error("There is no such key in cache");
+		} else {
+			_cache_items_list.splice(_cache_items_list.begin(), _cache_items_list, it->second);
+			return it->second->second;
+		}
+	}
+	
+	bool exists(const key_t& key) const {
+		return _cache_items_map.find(key) != _cache_items_map.end();
+	}
+	
+	size_t size() const {
+		return _cache_items_map.size();
+	}
+	
+private:
+	std::list<key_value_pair_t> _cache_items_list;
+	std::unordered_map<key_t, list_iterator_t> _cache_items_map;
+	size_t _max_size;
+};
+
+} // namespace lru
+
+#endif	/* _LRUCACHE_HPP_INCLUDED_ */
+

--- a/hdt-lib/tests/useHeaderStats.cpp
+++ b/hdt-lib/tests/useHeaderStats.cpp
@@ -21,7 +21,7 @@ void searchInHeader(int numPredicates, HDT* hdt,string metric) {
 	/*
 	 * Example of searching for a specific predicate
 	 */
-
+/*
 	string sub="http://example.org/predicate1";
 	int idPred = hdt->getDictionary()->stringToId(sub,PREDICATE);
 	stringstream ss;
@@ -35,8 +35,8 @@ void searchInHeader(int numPredicates, HDT* hdt,string metric) {
 		string valueofBranchingFactor = mysol->getObject();
 		cout<<"my value is:"<<valueofBranchingFactor<<endl;
 	}
+*/
 
-/*
 
 	for (int p = 1; p <= numPredicates; p++) {
 		stringstream ss;
@@ -49,7 +49,7 @@ void searchInHeader(int numPredicates, HDT* hdt,string metric) {
 			cout << hdt->getDictionary()->idToString(p,PREDICATE) << ": " + t->getObject() << endl;
 		}
 		delete tsol; // Remember to delete iterator to avoid memory leaks!
-	}*/
+	}
 }
 
 int main(int argc, char *argv[]) {

--- a/hdt-lib/tests/useHeaderStats.cpp
+++ b/hdt-lib/tests/useHeaderStats.cpp
@@ -1,0 +1,74 @@
+#include <iostream>
+#include <HDTManager.hpp>
+
+using namespace std;
+using namespace hdt;
+
+void help() {
+	cout << "$ useHeaderStats <inputHDTFile>"
+			<< endl;
+	cout
+			<< "Process the input HDT file and see some statistic in the header"
+			<< endl<< endl;
+	cout << "\t-h\t\t\tThis help" << endl<< endl;
+
+	cout<< "Note: The statistics follow the definitions in: Javier D. Fernández, Miguel A. Martínez-Prieto, Pablo de la Fuente Redondo, Claudio Gutiérrez. Characterizing RDF Datasets. Journal of Information Science, accepted for publication, 2016."<<endl;
+	//cout << "\t-v\tVerbose output" << endl;
+}
+
+void searchInHeader(int numPredicates, HDT* hdt,string metric) {
+
+	/*
+	 * Example of searching for a specific predicate
+	 */
+
+	string sub="http://example.org/predicate1";
+	int idPred = hdt->getDictionary()->stringToId(sub,PREDICATE);
+	stringstream ss;
+	ss << idPred;
+	string mysubj = "_:Predicate"+ss.str();
+	string pred = "<http://purl.org/HDT/hdt#PartialoutDegree_average>";
+	IteratorTripleString* tsol = hdt->getHeader()->search(mysubj.c_str(),
+				pred.c_str(), "");
+	if (tsol->hasNext()){
+		TripleString* mysol = tsol->next();
+		string valueofBranchingFactor = mysol->getObject();
+		cout<<"my value is:"<<valueofBranchingFactor<<endl;
+	}
+
+/*
+
+	for (int p = 1; p <= numPredicates; p++) {
+		stringstream ss;
+		ss << p;
+		string subj = "_:Predicate" + ss.str();
+		IteratorTripleString* tsol = hdt->getHeader()->search(subj.c_str(),
+				metric.c_str(), "");
+		if (tsol->hasNext()) {
+			TripleString* t = tsol->next();
+			cout << hdt->getDictionary()->idToString(p,PREDICATE) << ": " + t->getObject() << endl;
+		}
+		delete tsol; // Remember to delete iterator to avoid memory leaks!
+	}*/
+}
+
+int main(int argc, char *argv[]) {
+
+	// Load HDT file
+	if (argc<2){
+		cerr<< "Please provide an input HDT"<<endl;
+		help();
+		return 1;
+	}
+	HDT *hdt = HDTManager::mapHDT(argv[1]);
+
+
+	int numPredicates =  hdt->getDictionary()->getNpredicates();
+
+	cout<<"Partial OUT degree (branching factor SP?)"<<endl;
+	searchInHeader(numPredicates, hdt,"<http://purl.org/HDT/hdt#PartialoutDegree_average>");
+	cout<<endl<<"Partial in degree (branching factor PO)"<<endl;
+	searchInHeader(numPredicates, hdt,"<http://purl.org/HDT/hdt#PartialinDegree_average>");
+
+	delete hdt; // Remember to delete instance when no longer needed!
+}

--- a/hdt-lib/tools/modifyHeader.cpp
+++ b/hdt-lib/tools/modifyHeader.cpp
@@ -87,6 +87,10 @@ int main(int argc, char **argv) {
 	}
 	inputFile = argv[optind];
 	outputFile = argv[optind+1];
+	if (strcmp(inputFile,outputFile)==0){
+		cerr<< "ERROR: input and output files must me different" << endl <<endl;
+		return 1;
+	}
 
 	try {
 		// LOAD


### PR DESCRIPTION
The source needs to be compiled using -fPIC for embedding in a shared object.   Right now I do this using some `sed` magic, but that is needlessly complicated and causes the git submodule to be marked as dirty.  With this patch one can pass the desired options on the make command line easily.