### PR TITLE
Fix parsing abbreviated datatypes with Serd

### DIFF
--- a/hdt-lib/src/rdf/RDFParserSerd.cpp
+++ b/hdt-lib/src/rdf/RDFParserSerd.cpp
@@ -25,7 +25,7 @@ string RDFParserSerd::getString(const SerdNode *term) {
 			// ERROR BAD Curie / Prefix
 		}
 		out.append((const char *)uri_prefix.buf, uri_prefix.len);
-		out.append((const char *)uri_suffix.buf, uri_prefix.len);
+		out.append((const char *)uri_suffix.buf, uri_suffix.len);
 	}
 	return out;
 }
@@ -51,7 +51,7 @@ string RDFParserSerd::getStringObject(const SerdNode *term,
 	}
 	if(dataType!=NULL) {
 		out.append("^^<");
-		out.append((const char *)dataType->buf, dataType->n_bytes);
+		out.append(getString(dataType));
 		out.push_back('>');
 	}
 


### PR DESCRIPTION
Fixes a bug in the Serd parser when reading Turtle with abbreviated (qname) datatypes, as well as other issues with reading/expanding qnames.