### PR TITLE
Add Serd serializer

### DIFF
--- a/hdt-lib/qmake/hdt-lib.pro
+++ b/hdt-lib/qmake/hdt-lib.pro
@@ -74,6 +74,7 @@ SOURCES += \
     ../src/rdf/RDFParser.cpp \
     ../src/rdf/RDFSerializerNTriples.cpp \
     ../src/rdf/RDFSerializerRaptor.cpp \
+    ../src/rdf/RDFSerializerSerd.cpp \
     ../src/rdf/RDFSerializer.cpp \
     ../src/util/fileUtil.cpp \
     ../src/rdf/RDFParserRaptorCallback.cpp \
@@ -149,6 +150,7 @@ HEADERS += \
     ../src/rdf/RDFParserNtriples.hpp \
     ../src/rdf/RDFSerializerNTriples.hpp \
     ../src/rdf/RDFSerializerRaptor.hpp \
+    ../src/rdf/RDFSerializerSerd.hpp \
     ../src/rdf/RDFParserRaptorCallback.hpp \
     ../src/rdf/RDFParserSerd.hpp \
     ../src/sparql/VarBindingInterface.hpp \

--- a/hdt-lib/src/rdf/RDFSerializer.cpp
+++ b/hdt-lib/src/rdf/RDFSerializer.cpp
@@ -9,6 +9,9 @@
 #ifdef HAVE_RAPTOR
 #include "RDFSerializerRaptor.hpp"
 #endif
+#ifdef HAVE_SERD
+#include "RDFSerializerSerd.hpp"
+#endif
 #include "RDFSerializerNTriples.hpp"
 
 namespace hdt {
@@ -16,7 +19,9 @@ namespace hdt {
 RDFSerializer *RDFSerializer::getSerializer(std::ostream &out, RDFNotation notation) {
 
 #ifdef HAVE_RAPTOR
-		return new RDFSerializerRaptor(out, notation);
+	return new RDFSerializerRaptor(out, notation);
+#elif defined(HAVE_SERD)
+	return new RDFSerializerSerd(out, notation);
 #else
 	if(notation==NTRIPLES) {
 		return new RDFSerializerNTriples(out,notation);
@@ -30,6 +35,8 @@ RDFSerializer *RDFSerializer::getSerializer(const char *fileName, RDFNotation no
 
 #ifdef HAVE_RAPTOR
 	return new RDFSerializerRaptor(fileName, notation);
+#elif defined(HAVE_SERD)
+	return new RDFSerializerSerd(fileName, notation);
 #else
 	if(notation==NTRIPLES) {
 		return new RDFSerializerNTriples(fileName,notation);

--- a/hdt-lib/src/rdf/RDFSerializerSerd.cpp
+++ b/hdt-lib/src/rdf/RDFSerializerSerd.cpp
@@ -1,0 +1,140 @@
+#ifdef HAVE_SERD
+
+#include <cstdint>
+#include <cstdio>
+#include <stdexcept>
+
+#include "RDFSerializerSerd.hpp"
+
+namespace hdt {
+
+static SerdSyntax getType(RDFNotation notation) {
+	switch (notation) {
+	case NTRIPLES:
+		return SERD_NTRIPLES;
+	case NQUAD:
+		return SERD_NQUADS;
+	case TURTLE:
+		return SERD_TURTLE;
+	default:
+		throw std::runtime_error("Serd seriaizer only supports ntriples, nquads, and turtle.");
+	}
+}
+
+static size_t file_sink(const void* buf, size_t len, void* stream)
+{
+	return fwrite(buf, len, 1, reinterpret_cast<FILE*>(stream));
+}
+
+RDFSerializerSerd::RDFSerializerSerd(const char *fileName,
+                                     RDFNotation notation)
+	: RDFSerializer(notation)
+	, file(fopen(fileName, "w"))
+	, env(serd_env_new(NULL))
+	, writer(serd_writer_new(getType(notation), SERD_STYLE_ASCII,
+	                         env, NULL, file_sink, file))
+{
+}
+
+static size_t stream_sink(const void* buf, size_t len, void* stream)
+{
+	std::ostream *out = reinterpret_cast<std::ostream *>(stream);
+	if (out->good()) {
+		out->write((const char *)buf, len);
+		return len;
+	}
+	return 0;
+}
+
+RDFSerializerSerd::RDFSerializerSerd(std::ostream &s, RDFNotation notation)
+	: RDFSerializer(notation)
+	, file(NULL)
+	, env(serd_env_new(NULL))
+	, writer(serd_writer_new(getType(notation), SERD_STYLE_ASCII,
+	                         env, NULL, stream_sink, &s))
+{
+}
+
+RDFSerializerSerd::~RDFSerializerSerd()
+{
+	serd_writer_finish(writer);
+	serd_writer_free(writer);
+	if (file) {
+		fclose(file);
+	}
+}
+
+SerdNode getTerm(const string &str, SerdNode* datatype, SerdNode* lang)
+{
+	if (str.empty()) {
+		throw std::runtime_error("Empty Value on triple!");
+	}
+
+	const uint8_t *const buf = (const uint8_t*)str.c_str();
+	const size_t         len = str.length();
+	if (str.at(0) == '"') {
+		size_t       endQuote = len - 1;
+		const size_t dpos     = str.find("\"^^");
+		if (dpos != string::npos) {
+			if (!datatype) {
+				throw std::runtime_error("Unexpected datatype");
+			}
+
+			const uint8_t* datatypeStart = buf + dpos + 3;
+			if (*datatypeStart == '<') {
+				*datatype = serd_node_from_substring(
+					SERD_URI, datatypeStart + 1, len - dpos - 5);
+			} else {
+				*datatype = serd_node_from_substring(
+					SERD_CURIE, datatypeStart, len - dpos - 4);
+			}
+			endQuote = dpos;
+		}
+
+		const size_t lpos = str.find("\"@");
+		if (lpos != string::npos) {
+			if (!lang) {
+				throw std::runtime_error("Unexpected language");
+			}
+
+			*lang    = serd_node_from_string(SERD_LITERAL, buf + lpos + 2);
+			endQuote = lpos;
+		}
+
+		return serd_node_from_substring(SERD_LITERAL, buf + 1, endQuote - 1);
+	} else if (str.at(0) == '_') {
+		return serd_node_from_string(SERD_BLANK, buf + 2);
+	} else {
+		return serd_node_from_string(SERD_URI, buf);
+	}
+
+	return SERD_NODE_NULL;
+}
+
+void RDFSerializerSerd::serialize(IteratorTripleString *it,
+                                  ProgressListener     *listener,
+                                  unsigned int          totalTriples)
+{
+	for (unsigned n = 0; it->hasNext(); ++n) {
+		const TripleString *ts = it->next();
+		if (!ts->isEmpty()) {
+			SerdNode subject   = getTerm(ts->getSubject(), NULL, NULL);
+			SerdNode predicate = getTerm(ts->getPredicate(), NULL, NULL);
+			SerdNode datatype  = SERD_NODE_NULL;
+			SerdNode lang      = SERD_NODE_NULL;
+			SerdNode object    = getTerm(ts->getObject(), &datatype, &lang);
+
+			serd_writer_write_statement(
+				writer, 0, NULL,
+				&subject, &predicate, &object, &datatype, &lang);
+
+			NOTIFYCOND(listener, "Exporting HDT to RDF", n, totalTriples);
+		}
+	}
+}
+
+}
+
+#else
+int RDFSerializerSerdDummySymbol;
+#endif

--- a/hdt-lib/src/rdf/RDFSerializerSerd.hpp
+++ b/hdt-lib/src/rdf/RDFSerializerSerd.hpp
@@ -1,0 +1,33 @@
+#ifndef RDFSERIALIZERSERD_H_
+#define RDFSERIALIZERSERD_H_
+
+#ifdef HAVE_SERD
+
+#include <serd-0/serd/serd.h>
+
+#include "RDFSerializer.hpp"
+
+namespace hdt {
+
+class RDFSerializerSerd : public RDFSerializer {
+private:
+	FILE       *file;
+	SerdEnv    *env;
+	SerdWriter *writer;
+
+public:
+	RDFSerializerSerd(const char *fileName, RDFNotation notation);
+	RDFSerializerSerd(std::ostream &s, RDFNotation notation);
+
+	virtual ~RDFSerializerSerd();
+
+	void serialize(IteratorTripleString *it,
+	               ProgressListener *listener=NULL,
+	               unsigned int totalTriples=0);
+};
+
+}
+
+#endif
+
+#endif /* RDFSERIALIZERSERD_H_ */


### PR DESCRIPTION
Add ability to serialize NTriples, NQuads, and Turtle with Serd with zero copying from provided strings.

Successful round-tripping of all object term types (URI, CURIE, blank node, raw literal, language literal, literal with URI datatype, literal with CURIE datatype) from/to Turtle tested manually.

Requires latest development version of serd from git, 0.27.2.

Partially addresses #53 