### PR TITLE
Clean up console output

### DIFF
--- a/hdt-lib/tools/hdt2rdf.cpp
+++ b/hdt-lib/tools/hdt2rdf.cpp
@@ -48,15 +48,20 @@ void help() {
 	cout << "\t-V\tPrints the HDT version number." << endl;
 	//cout << "\t-v\tVerbose output" << endl;
 
+	cout << "\t-p\tPrints a progress indicator." << endl;
 }
 
 int main(int argc, char **argv) {
 	int c;
 	string rdfFormat, inputFile, outputFile;
 	RDFNotation notation = NTRIPLES;
+	bool showProgress=false;
 
-	while( (c = getopt(argc,argv,"f:V:"))!=-1) {
+	while( (c = getopt(argc,argv,"pf:V:"))!=-1) {
 		switch(c) {
+		case 'p':
+			showProgress = true;
+			break;
 		case 'f':
 			rdfFormat = optarg;
 			cerr << "Format: " << rdfFormat << endl;
@@ -112,8 +117,8 @@ int main(int argc, char **argv) {
 	}
 
 	try {
-		StdoutProgressListener progress;
-		HDT *hdt = HDTManager::mapHDT(inputFile.c_str(), &progress);
+		ProgressListener* progress = showProgress ? new StdoutProgressListener() : NULL;
+		HDT *hdt = HDTManager::mapHDT(inputFile.c_str(), progress);
 
 		if(outputFile!="-") {
 			RDFSerializer *serializer = RDFSerializer::getSerializer(outputFile.c_str(), notation);
@@ -125,6 +130,7 @@ int main(int argc, char **argv) {
 			delete serializer;
 		}
 		delete hdt;
+		delete progress;
 	} catch (std::exception& e) {
 		cerr << "ERROR: " << e.what() << endl;
 		return 1;

--- a/hdt-lib/tools/hdt2rdf.cpp
+++ b/hdt-lib/tools/hdt2rdf.cpp
@@ -46,25 +46,27 @@ void help() {
 	cout << "\t-h\t\t\tThis help" << endl;
 	cout << "\t-f\t<format>\tRDF Format of the output" << endl;
 	cout << "\t-V\tPrints the HDT version number." << endl;
-	//cout << "\t-v\tVerbose output" << endl;
-
 	cout << "\t-p\tPrints a progress indicator." << endl;
+	cout << "\t-v\tVerbose output" << endl;
 }
 
 int main(int argc, char **argv) {
 	int c;
 	string rdfFormat, inputFile, outputFile;
 	RDFNotation notation = NTRIPLES;
+	bool verbose=false;
 	bool showProgress=false;
 
-	while( (c = getopt(argc,argv,"pf:V:"))!=-1) {
+	while( (c = getopt(argc,argv,"vpf:V:"))!=-1) {
 		switch(c) {
+		case 'v':
+			verbose = true;
+			break;
 		case 'p':
 			showProgress = true;
 			break;
 		case 'f':
 			rdfFormat = optarg;
-			cerr << "Format: " << rdfFormat << endl;
 			break;
 		case 'V':
 			cerr << HDTVersion::get_version_string(".") << endl;
@@ -75,6 +77,8 @@ int main(int argc, char **argv) {
 			return 1;
 		}
 	}
+
+#define vout if (!verbose) {} else std::cerr /* Verbose output */
 
 	if(argc-optind<2) {
 		cerr << "ERROR: You must supply an input and output" << endl << endl;
@@ -99,6 +103,7 @@ int main(int argc, char **argv) {
 			help();
 			return 1;
 		}
+		vout << "Format: " << rdfFormat << endl;
 	}
 
 	inputFile = argv[optind];

--- a/hdt-lib/tools/rdf2hdt.cpp
+++ b/hdt-lib/tools/rdf2hdt.cpp
@@ -53,14 +53,14 @@ void help() {
 	cout << "\t-f\t<format>\tFormat of the RDF input (ntriples, nquad, n3, turtle, rdfxml)" << endl;
 	cout << "\t-B\t\"<base URI>\"\tBase URI of the dataset." << endl;
 	cout << "\t-V\tPrints the HDT version number." << endl;
-	//cout << "\t-v\tVerbose output" << endl;
 	cout << "\t-p\tPrints a progress indicator." << endl;
+	cout << "\t-v\tVerbose output" << endl;
 }
 
 int main(int argc, char **argv) {
 	string inputFile;
 	string outputFile;
-	bool verbose=false; // NOTE: generates -Wunused-but-set-variable warning.
+	bool verbose=false;
 	bool showProgress=false;
 	bool generateIndex=false;
 	string configFile;
@@ -75,11 +75,9 @@ int main(int argc, char **argv) {
 		switch(c) {
 		case 'c':
 			configFile = optarg;
-			cout << "Configfile: " << configFile << endl;
 			break;
 		case 'o':
 			options = optarg;
-			cout << "Options: " << options << endl;
 			break;
 		case 'v':
 			verbose = true;
@@ -89,7 +87,6 @@ int main(int argc, char **argv) {
 			break;
 		case 'f':
 			rdfFormat = optarg;
-			cout << "RDF format: " << rdfFormat << endl;
 			break;
 		case 'B':
 			baseUri = optarg;
@@ -101,14 +98,23 @@ int main(int argc, char **argv) {
 			cout << HDTVersion::get_version_string(".") << endl;
 			return 0;
 		default:
-			cout << "ERROR: Unknown option" << endl;
+			cerr << "ERROR: Unknown option" << endl;
 			help();
 			return 1;
 		}
 	}
 
+#define vout if (!verbose) {} else std::cerr /* Verbose output */
+
+	if (!configFile.empty()) {
+		vout << "Configfile: " << configFile << endl;
+	}
+	if (!options.empty()) {
+		vout << "Options: " << options << endl;
+	}
+
 	if(argc-optind<2) {
-		cout << "ERROR: You must supply an input and output" << endl << endl;
+		cerr << "ERROR: You must supply an input and output" << endl << endl;
 		help();
 		return 1;
 	}
@@ -117,13 +123,13 @@ int main(int argc, char **argv) {
 	outputFile = argv[optind+1];
 
 	if(inputFile=="") {
-		cout << "ERROR: You must supply an RDF input file" << endl << endl;
+		cerr << "ERROR: You must supply an RDF input file" << endl << endl;
 		help();
 		return 1;
 	}
 
 	if(outputFile=="") {
-		cout << "ERROR: You must supply an HDT output file" << endl << endl;
+		cerr << "ERROR: You must supply an HDT output file" << endl << endl;
 		help();
 		return 1;
 	}
@@ -144,10 +150,11 @@ int main(int argc, char **argv) {
 		} else if(rdfFormat=="rdfxml") {
 			notation = XML;
 		} else {
-			cout << "ERROR: The RDF input format must be one of: (ntriples, nquad, n3, turtle, rdfxml)" << endl;
+			cerr << "ERROR: The RDF input format must be one of: (ntriples, nquad, n3, turtle, rdfxml)" << endl;
 			help();
 			return 1;
 		}
+		vout << "RDF format: " << rdfFormat << endl;
 	}
 
 	// Process
@@ -173,11 +180,11 @@ int main(int argc, char **argv) {
 		out.close();
 
 		globalTimer.stop();
-		cout << "HDT Successfully generated.                        " << endl;
-		cout << "Total processing time: ";
-		cout << "Clock(" << globalTimer.getRealStr();
-		cout << ")  User(" << globalTimer.getUserStr();
-		cout << ")  System(" << globalTimer.getSystemStr() << ")" << endl;
+		vout << "HDT Successfully generated." << endl;
+		vout << "Total processing time: ";
+		vout << "Clock(" << globalTimer.getRealStr();
+		vout << ")  User(" << globalTimer.getUserStr();
+		vout << ")  System(" << globalTimer.getSystemStr() << ")" << endl;
 
 		if(generateIndex) {
 			hdt = HDTManager::indexedHDT(hdt, progress);


### PR DESCRIPTION
Adds progress and verbose flags, fixes pollution of `stdout` with log messages, and addresses #57 at least for `rdf2hdt` and `hdt2rdf`.