### PR TITLE
Reduce string copying overhead

### DIFF
--- a/hdt-it/hdtcontroller.cpp
+++ b/hdt-it/hdtcontroller.cpp
@@ -60,7 +60,7 @@ void HDTController::updateOnHDTChanged()
     emit datasetChanged();
 }
 
-void HDTController::importRDFFile(QString file, string &baseUri, hdt::RDFNotation notation, hdt::HDTSpecification &spec)
+void HDTController::importRDFFile(QString file, const string &baseUri, hdt::RDFNotation notation, hdt::HDTSpecification &spec)
 {
     closeHDT();
 

--- a/hdt-it/hdtcontroller.hpp
+++ b/hdt-it/hdtcontroller.hpp
@@ -52,7 +52,7 @@ public:
     bool hasHDT();
     void openHDTFile(QString file);
     void saveHDTFile(QString file);
-    void importRDFFile(QString file, string &baseUri, hdt::RDFNotation notation, hdt::HDTSpecification &spec);
+    void importRDFFile(QString file, const string &baseUri, hdt::RDFNotation notation, hdt::HDTSpecification &spec);
     void exportRDFFile(QString file, hdt::RDFNotation notation);
     void exportResultsRDFFile(QString file, hdt::RDFNotation notation);
     void closeHDT();

--- a/hdt-it/hdtit.cpp
+++ b/hdt-it/hdtit.cpp
@@ -119,7 +119,7 @@ void HDTit::openHDTFile(QString &file)
     hdtChanged(file);
 }
 
-void HDTit::importRDFFile(QString &file, string &baseUri, hdt::RDFNotation notation, hdt::HDTSpecification &spec)
+void HDTit::importRDFFile(QString &file, const string &baseUri, hdt::RDFNotation notation, hdt::HDTSpecification &spec)
 {
     hdtController->importRDFFile(file, baseUri, notation, spec);
 

--- a/hdt-it/hdtit.hpp
+++ b/hdt-it/hdtit.hpp
@@ -34,7 +34,7 @@ public:
     ~HDTit();
 
     void openHDTFile(QString &file);
-    void importRDFFile(QString &file, string &baseUri, hdt::RDFNotation notation, hdt::HDTSpecification &spec);
+    void importRDFFile(QString &file, const string &baseUri, hdt::RDFNotation notation, hdt::HDTSpecification &spec);
 
     HDTController *getManager();
 private slots:

--- a/hdt-it/hdtoperation.cpp
+++ b/hdt-it/hdtoperation.cpp
@@ -168,7 +168,7 @@ void HDTOperation::saveToHDT(QString &fileName)
     this->fileName = fileName;
 }
 
-void HDTOperation::loadFromRDF(hdt::HDTSpecification &spec, QString &fileName, hdt::RDFNotation notation, string &baseUri)
+void HDTOperation::loadFromRDF(hdt::HDTSpecification &spec, QString &fileName, hdt::RDFNotation notation, const string &baseUri)
 {
     this->op = RDF_READ;
     this->spec = spec;

--- a/hdt-it/hdtoperation.hpp
+++ b/hdt-it/hdtoperation.hpp
@@ -50,7 +50,7 @@ public:
     HDTOperation(hdt::HDT *hdt, HDTCachedInfo *hdtInfo);
     void saveToRDF(QString &fileName, hdt::RDFNotation notation);
     void saveToHDT(QString &fileName);
-    void loadFromRDF(hdt::HDTSpecification &spec, QString &fileName, hdt::RDFNotation notation, string &baseUri);
+    void loadFromRDF(hdt::HDTSpecification &spec, QString &fileName, hdt::RDFNotation notation, const string &baseUri);
     void loadFromHDT(QString &fileName);
     void exportResults(QString &fileName, hdt::IteratorTripleString *iterator, unsigned int numResults, hdt::RDFNotation notation);
     hdt::HDT *getHDT();

--- a/hdt-lib/include/Dictionary.hpp
+++ b/hdt-lib/include/Dictionary.hpp
@@ -91,12 +91,9 @@ public:
     * @return resultant TripleSTring
     */
     void tripleIDtoTripleString(TripleID &tripleID, TripleString &ts) {
-    	string s = idToString(tripleID.getSubject(), SUBJECT);
-    	string p = idToString(tripleID.getPredicate(), PREDICATE);
-    	string o = idToString(tripleID.getObject(), OBJECT);
-    	ts.setSubject(s);
-    	ts.setPredicate(p);
-    	ts.setObject(o);
+	    ts.setSubject(idToString(tripleID.getSubject(), SUBJECT));
+    	ts.setPredicate(idToString(tripleID.getPredicate(), PREDICATE));
+    	ts.setObject(idToString(tripleID.getObject(), OBJECT));
     }
 
     /** Number of total elements of the dictionary

--- a/hdt-lib/include/SingleTriple.hpp
+++ b/hdt-lib/include/SingleTriple.hpp
@@ -342,11 +342,11 @@ public:
 	 * Set Subject.
 	 * @param subject
 	 */
-	void setSubject(std::string &subject) {
+	void setSubject(const std::string &subject) {
 		this->subject = subject;
 	}
 
-	inline void setAll(std:: string &subject, std:: string &predicate, std:: string &object) {
+	inline void setAll(const std::string &subject, const std::string &predicate, const std::string &object) {
 		this->subject = subject;
 		this->predicate = predicate;
 		this->object = object;
@@ -364,7 +364,7 @@ public:
 	 *
 	 * @param predicate
 	 */
-	void setPredicate(std::string &predicate) {
+	void setPredicate(const std::string &predicate) {
 		this->predicate = predicate;
 	}
 
@@ -380,7 +380,7 @@ public:
 	 * Set Object.
 	 * @param object
 	 */
-	void setObject(std::string &object) {
+	void setObject(const std::string &object) {
 		this->object = object;
 	}
 

--- a/hdt-lib/src/dictionary/FourSectionDictionary.cpp
+++ b/hdt-lib/src/dictionary/FourSectionDictionary.cpp
@@ -89,7 +89,7 @@ std::string FourSectionDictionary::idToString(unsigned int id, TripleComponentRo
 	if(localid<=section->getLength()) {
 		const char * ptr = (const char *)section->extract(localid);
 		if(ptr!=NULL) {
-			string out = ptr;
+			const string out(ptr);
 			section->freeString((unsigned char*)ptr);
 			return out;
 		} else {

--- a/hdt-lib/src/dictionary/LiteralDictionary.cpp
+++ b/hdt-lib/src/dictionary/LiteralDictionary.cpp
@@ -94,7 +94,7 @@ std::string LiteralDictionary::idToString(unsigned int id, TripleComponentRole p
 	if (localid <= section->getLength()) {
 		const char * ptr = (const char *) section->extract(localid);
 		if (ptr != NULL) {
-			string out = ptr;
+			const string out(ptr);
 			//section->freeString((unsigned char*)ptr);
                         // TODO: find out why overloaded function 'freeString' isn't getting called, this solves it for now
                         delete [] ptr;

--- a/hdt-lib/src/dictionary/PlainDictionary.cpp
+++ b/hdt-lib/src/dictionary/PlainDictionary.cpp
@@ -99,11 +99,10 @@ std::string PlainDictionary::idToString(unsigned int id, TripleComponentRole pos
 
 	if(localid<vector.size()) {
 		DictionaryEntry *entry = vector[localid];
-		string result(entry->str);
-		return result;
+		return std::string(entry->str);
 	}
 
-	return string();
+	return std::string();
 }
 
 unsigned int PlainDictionary::stringToId(const std::string &key, TripleComponentRole position)

--- a/hdt-lib/src/hdt/BasicHDT.cpp
+++ b/hdt-lib/src/hdt/BasicHDT.cpp
@@ -351,7 +351,7 @@ void BasicHDT::loadTriples(const char* fileName, const char* baseUri, RDFNotatio
 	//cerr << triples->getNumberOfElements() << " triples added in " << st << endl << endl;
 }
 
-void BasicHDT::fillHeader(string& baseUri) {
+void BasicHDT::fillHeader(const string& baseUri) {
 	string formatNode = "_:format";
 	string dictNode = "_:dictionary";
 	string triplesNode = "_:triples";
@@ -444,8 +444,7 @@ void BasicHDT::addDictionaryFromHDT(const char *fileName, ModifiableDictionary *
 
         cerr << endl << "Load dictionary from " << fileName << endl;
         for(long long int i=0;i<otherDict->getNsubjects();i++) {
-                string a = otherDict->idToString(i+1, SUBJECT);
-                dict->insert(a, SUBJECT);
+                dict->insert(otherDict->idToString(i+1, SUBJECT), SUBJECT);
 
                 if ((listener != NULL) && (i % 100000) == 0) {
                         sprintf(str, "%lld subjects added.", i);
@@ -454,13 +453,11 @@ void BasicHDT::addDictionaryFromHDT(const char *fileName, ModifiableDictionary *
         }
 
         for(long long int i=0;i<otherDict->getNpredicates();i++) {
-                string a = otherDict->idToString(i+1, PREDICATE);
-                dict->insert(a, PREDICATE);
+                dict->insert(otherDict->idToString(i+1, PREDICATE), PREDICATE);
         }
 
         for(long long int i=0;i<otherDict->getNobjects();i++) {
-                string a = otherDict->idToString(i+1, OBJECT);
-                dict->insert(a, OBJECT);
+                dict->insert(otherDict->idToString(i+1, OBJECT), OBJECT);
 
                 if ((listener != NULL) && (i % 100000) == 0) {
                         sprintf(str, "%lld objects added.", i);
@@ -537,7 +534,7 @@ void BasicHDT::loadTriplesFromHDTs(const char** fileNames, size_t numFiles, cons
 	        LogSequence2 subjectMap(bits(dictionary->getNsubjects()), nsubjects);
 	        subjectMap.resize(nsubjects);
 	        for(unsigned int i=0;i<nsubjects;i++) {
-	        	string str = dict->idToString(i+1, SUBJECT);
+	        	const string str = dict->idToString(i+1, SUBJECT);
 	        	unsigned int newid = dictionary->stringToId(str, SUBJECT);
 	        	subjectMap.set(i, newid);
 	        }
@@ -546,7 +543,7 @@ void BasicHDT::loadTriplesFromHDTs(const char** fileNames, size_t numFiles, cons
 	        LogSequence2 predicateMap(bits(dictionary->getNpredicates()), npredicates);
 	        predicateMap.resize(npredicates);
 	        for(unsigned int i=0;i<npredicates;i++) {
-	        	string str = dict->idToString(i+1, PREDICATE);
+	        	const string str = dict->idToString(i+1, PREDICATE);
 	        	unsigned int newid = dictionary->stringToId(str, PREDICATE);
 	        	predicateMap.set(i, newid);
 	        }
@@ -555,7 +552,7 @@ void BasicHDT::loadTriplesFromHDTs(const char** fileNames, size_t numFiles, cons
 	        LogSequence2 objectMap(bits(dictionary->getNobjects()), nobjects);
 	        objectMap.resize(nobjects);
 	        for(unsigned int i=0;i<nobjects;i++) {
-	        	string str = dict->idToString(i+1, OBJECT);
+	        	const string str = dict->idToString(i+1, OBJECT);
 	        	unsigned int newid = dictionary->stringToId(str, OBJECT);
 	        	objectMap.set(i, newid);
 	        }

--- a/hdt-lib/src/hdt/BasicHDT.hpp
+++ b/hdt-lib/src/hdt/BasicHDT.hpp
@@ -59,7 +59,7 @@ private:
 	void loadDictionaryFromHDTs(const char** fileName, size_t numFiles, const char* baseUri, ProgressListener* listener=NULL);
 	void loadTriplesFromHDTs(const char** fileNames, size_t numFiles, const char* baseUri, ProgressListener* listener=NULL);
 
-	void fillHeader(string &baseUri);
+	void fillHeader(const string &baseUri);
 
     size_t loadMMap(unsigned char *ptr, unsigned char *ptrMax, ProgressListener *listener=NULL);
     size_t loadMMapIndex(ProgressListener *listener=NULL);

--- a/hdt-lib/src/sparql/QueryProcessor.hpp
+++ b/hdt-lib/src/sparql/QueryProcessor.hpp
@@ -61,9 +61,8 @@ public:
 	}
 	virtual string getVar(unsigned int numvar) {
 		unsigned int id = varID->getVarValue(numvar);
-		string varName(getVarName(numvar));
 
-		return dict->idToString(id, varRole.find(varName)->second);
+		return dict->idToString(id, varRole.find(getVarName(numvar))->second);
 	}
 	virtual const char *getVarName(unsigned int numvar) {
 		return varID->getVarName(numvar);

--- a/hdt-lib/tests/filterSearch.cpp
+++ b/hdt-lib/tests/filterSearch.cpp
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
 
 						pattern.setObject(results[i]);
 
-						string objStr = dict->idToString(results[i], OBJECT);
+						const string objStr = dict->idToString(results[i], OBJECT);
 
 						IteratorTripleID *it = triples->search(pattern);
 
@@ -162,7 +162,7 @@ int main(int argc, char **argv) {
 								// QUERY Q4
 								TripleID pat2(ts->getSubject(), 0, 0);
 								TripleString out;
-								string subjStr = dict->idToString(ts->getSubject(), SUBJECT);
+								const string subjStr = dict->idToString(ts->getSubject(), SUBJECT);
 
 								IteratorTripleID *it2 = triples->search(pat2);
 								while(it2->hasNext()) {

--- a/hdt-lib/tests/naiveComplete.cpp
+++ b/hdt-lib/tests/naiveComplete.cpp
@@ -133,7 +133,7 @@ int main(int argc, char **argv) {
 
 					pattern.setObject(results[i]);
 
-					string objStr = dict->idToString(results[i], OBJECT);
+					const string objStr = dict->idToString(results[i], OBJECT);
 
 					IteratorTripleID *it = triples->search(pattern);
 
@@ -150,7 +150,7 @@ int main(int argc, char **argv) {
 							// QUERY Q4
 							TripleID pat2(ts->getSubject(), 0, 0);
 							TripleString out;
-							string subjStr = dict->idToString(ts->getSubject(), SUBJECT);
+							const string subjStr = dict->idToString(ts->getSubject(), SUBJECT);
 
 							IteratorTripleID *it2 = triples->search(pat2);
 							while(it2->hasNext()) {


### PR DESCRIPTION
Modern compilers with move semantics can often elide copying for temporary
values and using const strings or references where appropriate (which is
everywhere possible) also avoids the need to copy in many cases.