### PR TITLE
Fix issue with incorrect cast to unsigned_int

### DIFF
--- a/hdt-lib/src/libdcs/CSD_PFC.cpp
+++ b/hdt-lib/src/libdcs/CSD_PFC.cpp
@@ -376,7 +376,7 @@ bool CSD_PFC::locateBlock(const unsigned char *s, size_t *block)
 	else
 		*block = center-1;
 
-	if(*block == (unsigned int)-1) {
+	if(*block == (size_t) -1) {
 		*block = 0;
 	}
 


### PR DESCRIPTION
This caused issues with the fillSuggestions function, throwing an error when the total block size was exactly 1. 