### PR TITLE
Refactor configure 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: cpp
 env:
   global:
     - LOCAL=$HOME/local
-    - TESTS_HDT="bit375 bitutiltest listener logarr streamtest testmax"
+    - TESTS_HDT="bit375 bitutiltest listener logarr serd streamtest testmax"
     - TESTS_CDS="testArray testBitSequence testHuffman testLCP testNPR testSequence testSuffixTree testTextIndex timeSequence toArray2 toArray"
 matrix:
   include:

--- a/configure.ac
+++ b/configure.ac
@@ -45,24 +45,30 @@ AC_ARG_WITH([zlib],
    [],[with_zlib=true])
 AS_IF([test x$with_zlib != xno],
   [PKG_CHECK_MODULES([ZLIB],[zlib],
-    [AC_DEFINE([HAVE_LIBZ],[1],[zlib available])
-  ])])
+    [AC_DEFINE([HAVE_LIBZ],[1],[zlib available])]
+    [EXTRAFLAGS="${EXTRAFLAGS} -DHAVE_LIBZ"]
+    [AC_SUBST(EXTRAFLAGS)])
+  ])
 
 AC_ARG_WITH([serd],
   AS_HELP_STRING([--with-serd], [Use serd library [default=yes] ]),
   [],[with_serd=true])
 AS_IF([test x$with_serd != xno],
   [PKG_CHECK_MODULES([SERD], [serd-0],
-    [AC_DEFINE([HAVE_SERD],[1],[Serd available])
-  ])])
+    [AC_DEFINE([HAVE_SERD],[1],[Serd available])]
+    [EXTRAFLAGS="${EXTRAFLAGS} -DHAVE_SERD"]
+    [AC_SUBST(EXTRAFLAGS)])
+  ])
 
 AC_ARG_WITH([kyoto],
   AS_HELP_STRING([--with-kyoto], [Use kyoto library [default=no]]),
   [], [with_kyoto=no])
 AS_IF([test x$with_kyoto != xno],
   [PKG_CHECK_MODULES([KYOTO], [kyotocabinet],
-     [AC_DEFINE([HAVE_KYOTO],[1],[kyoto available])
-  ])])
+     [AC_DEFINE([HAVE_KYOTO],[1],[kyoto available])]
+     [EXTRAFLAGS="${EXTRAFLAGS} -DHAVE_KYOTO"]
+     [AC_SUBST(EXTRAFLAGS)])
+  ])
 
 # Check for typedefs, structures, and compiler characteristics
 AC_HEADER_STDBOOL

--- a/libhdt/Makefile.am
+++ b/libhdt/Makefile.am
@@ -159,7 +159,7 @@ src/util/unicode.hpp\
 third/fdstream.hpp
 
 libhdt_la_CPPFLAGS = $(WARN_CFLAGS) -I$(top_builddir)/lib -I$(builddir)/include \
-$(KYOTO_CFLAGS) $(SERD_CFLAGS) $(ZLIB_CFLAGS)
+$(KYOTO_CFLAGS) $(SERD_CFLAGS) $(ZLIB_CFLAGS) $(EXTRAFLAGS)
 libhdt_la_LDFLAGS = $(SERD_LIBS) $(ZLIB_LIBS) $(KYOTO_LIBS)
 libhdt_la_LIBADD =
 

--- a/libhdt/src/rdf/RDFParserSerd.hpp
+++ b/libhdt/src/rdf/RDFParserSerd.hpp
@@ -5,7 +5,7 @@
 
 #include <stdint.h>
 
-#include <serd-0/serd/serd.h>
+#include <serd/serd.h>
 
 #include <HDTEnums.hpp>
 

--- a/libhdt/src/rdf/RDFSerializerSerd.hpp
+++ b/libhdt/src/rdf/RDFSerializerSerd.hpp
@@ -3,7 +3,7 @@
 
 #ifdef HAVE_SERD
 
-#include <serd-0/serd/serd.h>
+#include <serd/serd.h>
 
 #include "RDFSerializer.hpp"
 

--- a/libhdt/tests/Makefile.am
+++ b/libhdt/tests/Makefile.am
@@ -28,13 +28,14 @@ opendic \
 parse \
 patsearch \
 popcnt \
+serd \
 streamtest \
 testmax \
 wav
 
 AM_DEFAULT_SOURCE_EXT = .cpp
 
-AM_CPPFLAGS = -I@top_srcdir@/libhdt/include $(WARN_CFLAGS)
+AM_CPPFLAGS = -I@top_srcdir@/libhdt/include $(WARN_CFLAGS) $(EXTRAFLAGS)
 AM_LDFLAGS = $(SERD_LIBS) $(ZLIB_LIBS) $(KYOTO_LIBS)
 LDADD = ../libhdt.la
 

--- a/libhdt/tests/serd.cpp
+++ b/libhdt/tests/serd.cpp
@@ -1,0 +1,19 @@
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "RDFParser.hpp"
+
+using namespace std;
+using namespace hdt;
+
+int main(int argc, char **argv)
+{
+#ifdef HAVE_SERD
+	// If libhdt was not built with serd support, this will fail
+	cout << "calling serd " << endl;
+	RDFParserCallback::getParserCallback(TURTLE);
+#endif
+	return 0;
+}

--- a/libhdt/tools/Makefile.am
+++ b/libhdt/tools/Makefile.am
@@ -2,7 +2,7 @@ bin_PROGRAMS = hdt2rdf hdtInfo hdtSearch modifyHeader rdf2hdt replaceHeader sear
 
 AM_DEFAULT_SOURCE_EXT = .cpp
 
-AM_CPPFLAGS = -I@top_srcdir@/libhdt/include $(WARN_CFLAGS)
+AM_CPPFLAGS = -I@top_srcdir@/libhdt/include $(WARN_CFLAGS) $(EXTRAFLAGS)
 AM_LDFLAGS = $(SERD_LIBS) $(ZLIB_LIBS) $(KYOTO_LIBS)
 LDADD = ../libhdt.la
 


### PR DESCRIPTION
Following #99, I forgot that currently HDT is not importing `config.h` when using macros such as `HAVE_SERD`. I made a small trick to set the necessary preprocessor flags when required, effectively producing the objects depending on external libraries. This solution should be considered as a temporal, however. A proper solution will require the use of definitions found on config.h.

I included a small test to check that Serd support is actually built.