### PR TITLE
set minimum version for libserd in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AM_INIT_AUTOMAKE([foreign])
 AM_SILENT_RULES([yes])
 
 # CXXFLAGS is cleaned with user-defined flags.
-# configure includes by default some flags. 
+# configure includes by default some flags.
 AC_SUBST(CXXFLAGS,$CXXFLAGS)
 AC_PROG_CXX
 gl_EARLY
@@ -23,9 +23,9 @@ AX_CXX_COMPILE_STDCXX_11([noext],[mandatory])
 # If --disable-optimization is set, then CXXFLAGS is taken directly from the
 # user.
 
-# Building options 
+# Building options
 AC_MSG_CHECKING(whether to enable optimizations)
-AC_ARG_ENABLE([optimization], 
+AC_ARG_ENABLE([optimization],
   AS_HELP_STRING([--enable-optimization],[Build library with optimization parameters [default=yes]]),
   [AC_MSG_RESULT(${enableval})],
   [CXXFLAGS="${CXXFLAGS} -g -O2"]
@@ -34,12 +34,12 @@ AC_ARG_ENABLE([optimization],
 AC_MSG_CHECKING(whether to build libcds)
 AC_ARG_ENABLE([libcds],
   AS_HELP_STRING([--enable-libcds],[Build libcds [default=yes]]),
-  [AC_MSG_RESULT(${enableval})], 
+  [AC_MSG_RESULT(${enableval})],
   [enable_cds=yes]
   [AC_MSG_RESULT(yes)])
 AM_CONDITIONAL([WANTS_LIBCDS], [test x$enable_cds != xno])
 
-# Dependencies 
+# Dependencies
 AC_ARG_WITH([zlib],
   AS_HELP_STRING([--with-zlib], [Use z library [default=yes] ]),
    [],[with_zlib=true])
@@ -54,7 +54,7 @@ AC_ARG_WITH([serd],
   AS_HELP_STRING([--with-serd], [Use serd library [default=yes] ]),
   [],[with_serd=true])
 AS_IF([test x$with_serd != xno],
-  [PKG_CHECK_MODULES([SERD], [serd-0],
+  [PKG_CHECK_MODULES([SERD], [serd-0 >= 0.28.0],
     [AC_DEFINE([HAVE_SERD],[1],[Serd available])]
     [EXTRAFLAGS="${EXTRAFLAGS} -DHAVE_SERD"]
     [AC_SUBST(EXTRAFLAGS)])


### PR DESCRIPTION
According to  #110, libserd must be >= 0.28. 