### PR TITLE
remove JSON and XML from serialization-related CLIs

### DIFF
--- a/libhdt/tests/hdt2rdfNotMapping.cpp
+++ b/libhdt/tests/hdt2rdfNotMapping.cpp
@@ -79,10 +79,8 @@ int main(int argc, char **argv) {
 			notation = N3;
 		} else if(rdfFormat=="turtle") {
 			notation = TURTLE;
-		} else if(rdfFormat=="rdfxml") {
-			notation = XML;
 		} else {
-			cout << "ERROR: The RDF output format must be one of: (ntriples, n3, turtle, rdfxml)" << endl;
+			cout << "ERROR: The RDF output format must be one of: (ntriples, n3, turtle)" << endl;
 			help();
 			return 1;
 		}

--- a/libhdt/tools/hdt2rdf.cpp
+++ b/libhdt/tools/hdt2rdf.cpp
@@ -91,15 +91,10 @@ int main(int argc, char **argv) {
 			notation = NTRIPLES;
 		} else if(rdfFormat=="n3") {
 			notation = TURTLE;
-		} else if(rdfFormat=="json") {
-			notation = JSON;
-		}
-		else if(rdfFormat=="turtle") {
+		} else if(rdfFormat=="turtle") {
 			notation = TURTLE;
-		} else if(rdfFormat=="rdfxml") {
-			notation = XML;
 		} else {
-			cerr << "ERROR: The RDF output format must be one of: (ntriples, n3, turtle, rdfxml, json)" << endl;
+			cerr << "ERROR: The RDF output format must be one of: (ntriples, n3, turtle)" << endl;
 			help();
 			return 1;
 		}

--- a/libhdt/tools/rdf2hdt.cpp
+++ b/libhdt/tools/rdf2hdt.cpp
@@ -51,7 +51,7 @@ void help() {
     cout << "\t-i\t\t\tAlso generate index to solve all triple patterns." << endl;
     cout << "\t-c\t<configfile>\tHDT Config options file" << endl;
     cout << "\t-o\t<options>\tHDT Additional options (option1=value1;option2=value2;...)" << endl;
-    cout << "\t-f\t<format>\tFormat of the RDF input (n3, ntriples or nt, nquads or nq, rdfxml or xml, turtle or ttl)" << endl;
+    cout << "\t-f\t<format>\tFormat of the RDF input (n3, ntriples or nt, nquads or nq, turtle or ttl)" << endl;
     cout << "\t-B\t\"<base URI>\"\tBase URI of the dataset." << endl;
     cout << "\t-V\tPrints the HDT version number." << endl;
     cout << "\t-p\tPrints a progress indicator." << endl;
@@ -191,15 +191,12 @@ int main(int argc, char **argv) {
         notation = NQUAD;
     else if (rdfFormat == "turtle" || rdfFormat == "ttl")
         notation = TURTLE;
-    else if (rdfFormat == "rdfxml" || rdfFormat == "xml")
-        notation = XML;
     // -f or file extension detected, but didn't match any valid format.
     else {
         cerr << "ERROR: Detected \"" << rdfFormat << "\" input format. Must be one of:" << endl
              << "\t- n3" << endl
              << "\t- ntriples or nt" << endl
              << "\t- nquads or nq" << endl
-             << "\t- rdfxml or xml" << endl
              << "\t- turtle or ttl" << endl;
 
         return 1;


### PR DESCRIPTION
When testing #125 I saw that the CLIs still have some residue references to rdf xml. As we don't support these anymore, I removed these (including the option to serialize to json, as that's unsupported as well)