### PR TITLE
Add offset flag in hdtSearch

### DIFF
--- a/libhdt/include/Iterator.hpp
+++ b/libhdt/include/Iterator.hpp
@@ -255,6 +255,9 @@ public:
 	}
 	virtual void goToStart() {
 	}
+    virtual bool canGoTo(){
+        return false;
+    }
 	virtual size_t estimatedNumResults() {
 		return 0;
 	}

--- a/libhdt/src/hdt/TripleIDStringIterator.cpp
+++ b/libhdt/src/hdt/TripleIDStringIterator.cpp
@@ -41,7 +41,9 @@ TripleString *TripleIDStringIterator::previous() {
 void TripleIDStringIterator::goToStart() {
 	iterator->goToStart();
 }
-
+bool TripleIDStringIterator::canGoTo() {
+	return iterator->canGoTo();
+}
 size_t TripleIDStringIterator::estimatedNumResults() {
 	return iterator->estimatedNumResults();
 }

--- a/libhdt/src/hdt/TripleIDStringIterator.hpp
+++ b/libhdt/src/hdt/TripleIDStringIterator.hpp
@@ -26,6 +26,7 @@ public:
 	TripleString *next();
 	bool hasPrevious();
 	TripleString *previous();
+	bool canGoTo();
 	void goToStart();
 	size_t estimatedNumResults();
 	ResultEstimationType numResultEstimation();

--- a/libhdt/src/triples/BitmapTriplesIterators.cpp
+++ b/libhdt/src/triples/BitmapTriplesIterators.cpp
@@ -455,18 +455,23 @@ void MiddleWaveletIterator::skip(unsigned int pos) {
 	//goTo(predicateOcurrence+pos);
 
 	int numJumps = 0;
+    unsigned int posLeft = pos;
 	while ((numJumps<pos)&&(posZ<maxZ)){
-		if((posZ+pos)>nextZ) {
+		if((posZ+posLeft)>nextZ) {
 			 numJumps += (nextZ-posZ)+1; // count current jump
 			 predicateOcurrence++; // jump to the next occurrence
+             posLeft = pos-numJumps; // set remaining offset
 			 if (predicateOcurrence<=numOcurrences){
 				 posY = predicateIndex->getAppearance(patY, predicateOcurrence);
 				 posZ = prevZ = adjZ.find(posY);
 				 nextZ = adjZ.last(posY);
 			 }
+            else {
+                 throw std::runtime_error("Cannot goTo on this pattern.");
+             }
 
 		} else {
-			posZ=(posZ+pos);
+			posZ=(posZ+posLeft);
 			numJumps=pos;
 		}
 	}

--- a/libhdt/tools/hdtSearch.cpp
+++ b/libhdt/tools/hdtSearch.cpp
@@ -93,10 +93,23 @@ void iterate(HDT *hdt, char *query, ostream &out, bool measure, uint32_t offset)
 		StopWatch st;
 
         // Go to the right offset.
-		while(offset && it->hasNext()) {
-			it->next();
-			offset--;
-		}
+        if(it->canGoTo()) {
+            try {
+                it->skip(offset);
+                offset = 0;
+            }
+            catch (const runtime_error error) {
+                /*invalid offset*/
+                it->skip(it->estimatedNumResults()-1);
+                it->next();
+            }
+        }
+        else {
+            while(offset && it->hasNext()) {
+                it->next();
+                offset--;
+            }
+        }
 
         // Get results.
 		unsigned int numTriples=0;

--- a/libhdt/tools/hdtSearch.cpp
+++ b/libhdt/tools/hdtSearch.cpp
@@ -100,6 +100,7 @@ void iterate(HDT *hdt, char *query, ostream &out, bool measure, uint32_t offset)
             }
             catch (const runtime_error error) {
                 /*invalid offset*/
+                interruptSignal = 1;
             }
         }
         else {
@@ -147,7 +148,7 @@ int main(int argc, char **argv) {
 			break;
         case 'f':
             sstream << optarg;
-            sstream >> offset;
+            if(!(sstream >> offset)) offset=0;
             break;
 		case 'm':
 			measure = true;

--- a/libhdt/tools/hdtSearch.cpp
+++ b/libhdt/tools/hdtSearch.cpp
@@ -58,7 +58,7 @@ void help() {
 	cout << "\t-h\t\t\tThis help" << endl;
 	cout << "\t-q\t<query>\t\tLaunch query and exit." << endl;
 	cout << "\t-o\t<output>\tSave query output to file." << endl;
-    cout << "\t-f\t<offset>\tLimit the result list starting at the offset." << endl;
+    cout << "\t-f\t<offset>\tLimit the result list starting after the offset." << endl;
 	cout << "\t-m\t\t\tDo not show results, just measure query time." << endl;
 	cout << "\t-V\t\t\tPrints the HDT version number." << endl;
 	//cout << "\t-v\tVerbose output" << endl;

--- a/libhdt/tools/hdtSearch.cpp
+++ b/libhdt/tools/hdtSearch.cpp
@@ -100,8 +100,6 @@ void iterate(HDT *hdt, char *query, ostream &out, bool measure, uint32_t offset)
             }
             catch (const runtime_error error) {
                 /*invalid offset*/
-                it->skip(it->estimatedNumResults()-1);
-                it->next();
             }
         }
         else {

--- a/libhdt/tools/hdtSearch.cpp
+++ b/libhdt/tools/hdtSearch.cpp
@@ -38,6 +38,7 @@
 #include <getopt.h>
 #include <string.h>
 #include <string>
+#include <cstdint>
 #include <iostream>
 #include <fstream>
 #include "../src/util/StopWatch.hpp"
@@ -57,8 +58,9 @@ void help() {
 	cout << "\t-h\t\t\tThis help" << endl;
 	cout << "\t-q\t<query>\t\tLaunch query and exit." << endl;
 	cout << "\t-o\t<output>\tSave query output to file." << endl;
+    cout << "\t-f\t<offset>\tLimit the result list to the number given by the offset." << endl;
 	cout << "\t-m\t\t\tDo not show results, just measure query time." << endl;
-	cout << "\t-V\tPrints the HDT version number." << endl;
+	cout << "\t-V\t\t\tPrints the HDT version number." << endl;
 	//cout << "\t-v\tVerbose output" << endl;
 }
 
@@ -109,9 +111,11 @@ void iterate(HDT *hdt, char *query, ostream &out, bool measure) {
 int main(int argc, char **argv) {
 	int c;
 	string query, inputFile, outputFile;
+    stringstream sstream;
+    uint64_t offset;
 	bool measure = false;
 
-	while( (c = getopt(argc,argv,"hq:o:m:V"))!=-1) {
+	while( (c = getopt(argc,argv,"hq:o:f:mV"))!=-1) {
 		switch(c) {
 		case 'h':
 			help();
@@ -122,6 +126,10 @@ int main(int argc, char **argv) {
 		case 'o':
 			outputFile = optarg;
 			break;
+        case 'f':
+            sstream << optarg;
+            sstream >> offset;
+            break;
 		case 'm':
 			measure = true;
 			break;


### PR DESCRIPTION
- An offset flag (-f <offset>) is now available for hdtSearch. 
- Fix MiddleWaveletIterator::skip method since it was returning wrong results.
- Additionally, fix -m flag which was not working.