### PR TITLE
allow .gz as input file extension

### DIFF
--- a/libhdt/tools/rdf2hdt.cpp
+++ b/libhdt/tools/rdf2hdt.cpp
@@ -170,7 +170,7 @@ int main(int argc, char **argv) {
          * didn't have any extension. The default format is defined at the top
          * of this file: RDFNotation notation = NTRIPLES;
          */
-        if (rdfFormat == "")
+        if (rdfFormat == "" || rdfFormat == "gz")
         {
             rdfFormat = "nt";
             vout << "No input format detected. Using default: NTRIPLES." << endl;


### PR DESCRIPTION
Gzip is a valid extension for input files. When not explicitly passing a serialization, it will assume an ntriples file (compressed as gz)