### PR TITLE
Fix invalid comparison

### DIFF
--- a/libhdt/src/triples/BitmapTriplesIterators.cpp
+++ b/libhdt/src/triples/BitmapTriplesIterators.cpp
@@ -785,7 +785,7 @@ void ObjectIndexIterator::updateOutput() {
 
 bool ObjectIndexIterator::hasNext()
 {
-    return posIndex <= maxIndex;
+    return posIndex <= maxIndex && maxIndex >= 0;
 }
 
 TripleID *ObjectIndexIterator::next()


### PR DESCRIPTION
This fixes #156 

There happened to be an edge case where a **long long** variable was getting a negative value (-1) and then it was compared to a **size_t** variable. 

When there is an arithmetic comparison between size_t and and an (signed) long long operator, then the latter transforms into an unsigned version. In this issue,  hasNext() was comparing a positive number x (of type size_t) with -1 : return x <= -1 , but -1 was converted to size_t and consequently in a very large positive number.

Added an extra expression which checks if the variable is negative.