### PR TITLE
Fix buggy comparisons

### DIFF
--- a/libcds/src/static/coders/huff.cpp
+++ b/libcds/src/static/coders/huff.cpp
@@ -235,7 +235,7 @@ namespace cds_static
 		if (!enc) {
 			H.fst = new uint[H.depth+1];
 			H.fst[H.depth] = 0; dold = 0;
-			for (d=H.depth-1;d>=0;d--) {
+			for (d=H.depth-1;d!=(uint)-1;d--) {
 				dact = H.num[d+1];
 				H.fst[d] = (H.fst[d+1]+dact) >> 1;
 				H.num[d+1] = dold;

--- a/libhdt/src/bitsequence/BitSequence375.cpp
+++ b/libhdt/src/bitsequence/BitSequence375.cpp
@@ -288,7 +288,8 @@ BitSequence375 * BitSequence375::load(istream & in)
 	// Read array from file, byte-aligned.
 	size_t bytes = ret->numBytes(ret->numbits);
 	in.read((char*)&ret->data[0], bytes);
-	if(in.gcount()!=bytes) {
+	streamsize gc = in.gcount();
+	if(gc < 0 || static_cast<size_t>(gc)!=bytes) {
 		throw std::runtime_error("BitSequence375 error reading array of bits.");
 	}
 

--- a/libhdt/src/dictionary/FourSectionDictionary.cpp
+++ b/libhdt/src/dictionary/FourSectionDictionary.cpp
@@ -582,7 +582,7 @@ void FourSectionDictionary::getSuggestions(const char *base, hdt::TripleComponen
 	merge(v1.begin(),v1.end(), v2.begin(), v2.end(), std::back_inserter(out));
 
 	// Remove possible extra items
-	if(out.size()>maxResults) {
+	if((maxResults>=0) & (out.size()>static_cast<size_t>(maxResults))) {
 		out.resize(maxResults);
 	}
 }

--- a/libhdt/src/dictionary/FourSectionDictionary.cpp
+++ b/libhdt/src/dictionary/FourSectionDictionary.cpp
@@ -582,7 +582,7 @@ void FourSectionDictionary::getSuggestions(const char *base, hdt::TripleComponen
 	merge(v1.begin(),v1.end(), v2.begin(), v2.end(), std::back_inserter(out));
 
 	// Remove possible extra items
-	if((maxResults>=0) & (out.size()>static_cast<size_t>(maxResults))) {
+	if((maxResults>=0) && (out.size()>static_cast<size_t>(maxResults))) {
 		out.resize(maxResults);
 	}
 }

--- a/libhdt/src/dictionary/LiteralDictionary.cpp
+++ b/libhdt/src/dictionary/LiteralDictionary.cpp
@@ -430,7 +430,7 @@ uint32_t LiteralDictionary::substringToId(unsigned char *s, uint32_t len, uint32
 
 	if(fmIndex!=NULL) {
 		uint32_t ret = fmIndex->locate_substring(s, len, offset, limit, deduplicate, occs, num_occ);
-		for (int i=0;i<*num_occ;i++){
+		for (size_t i=0;i<*num_occ;i++){
 			(*occs)[i] = this->getGlobalId((*occs)[i], NOT_SHARED_OBJECT);
 		}
 		return ret;
@@ -706,7 +706,7 @@ void LiteralDictionary::getSuggestions(const char *base, hdt::TripleComponentRol
 	merge(v1.begin(), v1.end(), v2.begin(), v2.end(), std::back_inserter(out));
 
 	// Remove possible extra items
-	if (out.size() > maxResults) {
+	if ((maxResults >= 0) && (out.size() > static_cast<size_t>(maxResults))) {
 		out.resize(maxResults);
 	}
 }

--- a/libhdt/src/libdcs/CSD_FMIndex.cpp
+++ b/libhdt/src/libdcs/CSD_FMIndex.cpp
@@ -445,9 +445,9 @@ void csd::CSD_FMIndex::fillSuggestions(const char *base,
     uint32_t *results = NULL;
     size_t numresults = this->locate_substring(n_s, len + 1, &results);
     int maxIter = maxResults;
-    if (numresults < maxIter)
+    if (maxIter >= 0 && numresults < static_cast<size_t>(maxIter))
         maxIter = numresults;
-    for (int i = 0; i < numresults; i++) {
+    for (size_t i = 0; i < numresults; i++) {
         out.push_back((char*) (this->extract(results[i])));
     }
 }

--- a/libhdt/src/libdcs/CSD_PFC.cpp
+++ b/libhdt/src/libdcs/CSD_PFC.cpp
@@ -528,7 +528,7 @@ void CSD_PFC::fillSuggestions(const char *base, vector<std::string> &out, int ma
 		int cmp = strncmp(base, tmpStr.c_str(), baselen);
 		if(cmp==0) {
 			out.push_back(tmpStr);
-			if(out.size()>=maxResults) {
+			if(maxResults<0 || out.size()>=static_cast<size_t>(maxResults)) {
 				terminate=true;
 			}
 		} else if(cmp<0) {
@@ -552,7 +552,7 @@ void CSD_PFC::fillSuggestions(const char *base, vector<std::string> &out, int ma
 			int cmp = strncmp(base, tmpStr.c_str(), baselen);
 			if(cmp==0) {
 				out.push_back(tmpStr);
-				if(out.size()>=maxResults) {
+				if(maxResults<0 || out.size()>=static_cast<size_t>(maxResults)) {
 					terminate=true;
 				}
 			} else if(cmp<0) {

--- a/libhdt/src/sequence/AdjacencyList.cpp
+++ b/libhdt/src/sequence/AdjacencyList.cpp
@@ -233,7 +233,7 @@ size_t AdjacencyList::findNextAppearance(size_t oldpos, unsigned int element) {
 
 size_t AdjacencyList::findPreviousAppearance(size_t oldpos, unsigned int element) {
 	long long old=oldpos;
-    if(oldpos==-1 || element==0) {
+    if(oldpos==(size_t)-1 || element==0) {
         return -1;
     }
 

--- a/libhdt/src/triples/BitmapTriples.cpp
+++ b/libhdt/src/triples/BitmapTriples.cpp
@@ -488,7 +488,7 @@ void BitmapTriples::generateIndexFast(ProgressListener *listener) {
 
 		//cerr << "Item " << i << " in adjlist " << adjZlist << endl;
 		unsigned int pred = arrayY->get(adjZlist);
-		maxpred = pred>maxpred ? pred : maxpred;
+		maxpred = ((maxpred<0) || (pred>static_cast<size_t>(maxpred))) ? pred : maxpred;
 
         index[val-1].push_back(std::make_pair(adjZlist, pred));
 		NOTIFYCOND(&iListener, "Generating Object lists", i, arrayZ->getNumberOfElements());

--- a/libhdt/src/triples/BitmapTriplesIterators.cpp
+++ b/libhdt/src/triples/BitmapTriplesIterators.cpp
@@ -456,7 +456,7 @@ void MiddleWaveletIterator::skip(unsigned int pos) {
 
 	int numJumps = 0;
     unsigned int posLeft = pos;
-	while ((numJumps<pos)&&(posZ<maxZ)){
+	while ((numJumps<0 || static_cast<size_t>(numJumps)<pos)&&(posZ<maxZ)){
 		if((posZ+posLeft)>nextZ) {
 			 numJumps += (nextZ-posZ)+1; // count current jump
 			 predicateOcurrence++; // jump to the next occurrence
@@ -611,7 +611,7 @@ void IteratorY::updateOutput() {
 
 bool IteratorY::hasNext()
 {
-    return nextY!=-1 || posZ<=nextZ;
+    return nextY!=(size_t)-1 || posZ<=nextZ;
 }
 
 TripleID *IteratorY::next()
@@ -639,7 +639,7 @@ TripleID *IteratorY::next()
 
 bool IteratorY::hasPrevious()
 {
-	return prevY!=-1 || posZ>=prevZ;
+	return prevY!=(size_t)-1 || posZ>=prevZ;
 }
 
 TripleID *IteratorY::previous()
@@ -785,7 +785,7 @@ void ObjectIndexIterator::updateOutput() {
 
 bool ObjectIndexIterator::hasNext()
 {
-    return posIndex <= maxIndex && maxIndex >= 0;
+    return maxIndex >= 0 && posIndex <= static_cast<size_t>(maxIndex);
 }
 
 TripleID *ObjectIndexIterator::next()
@@ -804,7 +804,7 @@ TripleID *ObjectIndexIterator::next()
 
 bool ObjectIndexIterator::hasPrevious()
 {
-    return posIndex>minIndex;
+    return minIndex<0 || posIndex>static_cast<size_t>(minIndex);
 }
 
 TripleID *ObjectIndexIterator::previous()

--- a/libhdt/src/triples/TripleIterators.cpp
+++ b/libhdt/src/triples/TripleIterators.cpp
@@ -151,12 +151,12 @@ bool SequentialSearchIteratorTripleID::canGoTo(){
 }
 void SequentialSearchIteratorTripleID::goTo(unsigned int pos){
 	iterator->goToStart();
-	for (int i=0;i<=pos;i++){
+	for (size_t i=0;i<=pos;i++){
 		doFetchNext();
 	}
 }
 void SequentialSearchIteratorTripleID::skip(unsigned int pos){
-	for (int i=0;i<pos;i++){
+	for (size_t i=0;i<pos;i++){
 		doFetchNext();
 	}
 }

--- a/libhdt/src/triples/TriplesList.cpp
+++ b/libhdt/src/triples/TriplesList.cpp
@@ -333,7 +333,7 @@ void TriplesList::calculateDegree(string path, unsigned int numPredicates,unsign
 	const int nbins = 1000000;
 	map<int, Histogram*> hDegreePartialPerPredicate;
 
-	for (int i=1;i<=numPredicates;i++){
+	for (size_t i=1;i<=numPredicates;i++){
 		 Histogram* hDegreePart = new Histogram(0, maxval, nbins);
 		 hDegreePartialPerPredicate[i]=hDegreePart;
 	}
@@ -743,7 +743,7 @@ void TriplesList::calculateMinStats(string path, unsigned int numPredicates) {
 	const int nbins = 1000000;
 	map<int, Histogram*> hDegreePartialPerPredicate;
 
-	for (int i=1;i<=numPredicates;i++){
+	for (size_t i=1;i<=numPredicates;i++){
 		 Histogram* hDegreePart = new Histogram(0, maxval, nbins);
 		 hDegreePartialPerPredicate[i]=hDegreePart;
 	}
@@ -1068,7 +1068,7 @@ void TriplesList::calculateDegreeType(string path, unsigned int rdftypeID) {
 						listsofPredicates[listPredicates] + 1;
 
 				//register the number of lists per class
-				for (int k = 0; k < listClasses.size(); k++) {
+				for (size_t k = 0; k < listClasses.size(); k++) {
 					string concatenationClassPred = "c"; //to concanetate something different from an ID
 					std::stringstream ss;
 					ss << (unsigned int) (listClasses[k]);
@@ -1083,7 +1083,7 @@ void TriplesList::calculateDegreeType(string path, unsigned int rdftypeID) {
 					listofClassesPredicates[concatenationClassPred] =
 							listofClassesPredicates[concatenationClassPred] + 1;
 				}
-				for (int k = 0; k < pendingpartialycounts.size(); k++) {
+				for (size_t k = 0; k < pendingpartialycounts.size(); k++) {
 					hDegreePartial.add(pendingpartialycounts[k]);
 				}
 			}
@@ -1175,7 +1175,7 @@ void TriplesList::calculateDegreeType(string path, unsigned int rdftypeID) {
 				+ 1;
 
 		//register the number of lists per class
-		for (int k = 0; k < listClasses.size(); k++) {
+		for (size_t k = 0; k < listClasses.size(); k++) {
 			string concatenationClassPred = "c"; //to concanetate something different from an ID
 			std::stringstream ss;
 			ss << (unsigned int) (listClasses[k]);
@@ -1197,7 +1197,7 @@ void TriplesList::calculateDegreeType(string path, unsigned int rdftypeID) {
 		//cout << "\tpartial degree: " << ycount << endl;
 		hDegreePartial.add(ycount);
 
-		for (int k = 0; k < pendingpartialycounts.size(); k++) {
+		for (size_t k = 0; k < pendingpartialycounts.size(); k++) {
 			hDegreePartial.add(pendingpartialycounts[k]);
 		}
 


### PR DESCRIPTION
There are several comparisons between signed and unsigned variables which might end up in undefined behavior, such as this: #156. 

This PR fixes all of the invalid comparisons which appear as warnings during compilation. This fix is done by adding a proper expression which checks whether the signed variable is below 0. Also, the static cast prevents the appearance of the warning. Lastly, there are several replacements from _int_ to *size_t* and castings of *-1* to *(size_t) -1*.