### PR TITLE
Test compile c11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: cpp
 env:
   global:
     - LOCAL=$HOME/local
-    - TESTS_HDT="bit375 bitutiltest listener logarr serd streamtest testmax"
-    - TESTS_CDS="testArray testBitSequence testHuffman testLCP testNPR testSequence testSuffixTree testTextIndex timeSequence toArray2 toArray"
 matrix:
   include:
     - os: osx
@@ -50,8 +48,8 @@ script:
   - ./configure --prefix=$LOCAL CXX=$HDT_CPP
   - make -j2
   # Make and run selected tests. Most tests in HDT are failing
-  - TESTS=$TESTS_CDS make -e check -j2 -C libcds || ( cat libcds/tests/test-suite.log && exit -1)
-  - TESTS=$TESTS_HDT make -e check -j2 -C libhdt || ( cat libhdt/tests/test-suite.log && exit -1)
+  - make check -j2 -C libcds || ( cat libcds/tests/test-suite.log && exit -1)
+  - make check -j2 -C libhdt || ( cat libhdt/tests/test-suite.log && exit -1)
   # Install
   - make install
   - hdtSearch -q 0 libhdt/data/literals.hdt

--- a/libcds/tests/Makefile.am
+++ b/libcds/tests/Makefile.am
@@ -4,13 +4,13 @@ testBitSequence \
 testHuffman \
 testLCP \
 testNPR \
-testQuantile \
 testSequence \
 testSuffixTree \
 testTextIndex \
 timeSequence \
 toArray2 \
 toArray
+#testQuantile
 
 AM_DEFAULT_SOURCE_EXT = .cpp
 AM_CPPFLAGS = -I@top_srcdir@/libcds/include $(WARN_CFLAGS)

--- a/libhdt/tests/Makefile.am
+++ b/libhdt/tests/Makefile.am
@@ -1,38 +1,38 @@
 check_PROGRAMS = \
 bit375 \
 bitutiltest \
-cmp \
-confm \
-conops \
-conpfc \
-convert \
-conwav \
-csd \
-dic \
-filterSearch \
-genCache \
-genIndex \
-getobj \
-hdt2rdfNotMapping \
-hdtExtract \
-iter \
-joinsearch \
-jointest \
-kyoto \
 listener \
 logarr \
-mergeHDT \
-mincor \
-naiveComplete \
-opendic \
-parse \
-patsearch \
-popcnt \
-randomSolution \
 serd \
 streamtest \
-testmax \
-wav
+testmax
+#cmp \
+#confm \
+#conops \
+#conpfc \
+#convert \
+#conwav \
+#csd \
+#dic \
+#filterSearch \
+#genCache \
+#genIndex \
+#getobj \
+#hdt2rdfNotMapping \
+#hdtExtract \
+#iter \
+#joinsearch \
+#jointest \
+#kyoto \
+#mergeHDT \
+#mincor \
+#naiveComplete \
+#opendic \
+#parse \
+#patsearch \
+#popcnt \
+#randomSolution \
+#wav
 
 AM_DEFAULT_SOURCE_EXT = .cpp
 

--- a/libhdt/tests/Makefile.am
+++ b/libhdt/tests/Makefile.am
@@ -1,6 +1,7 @@
 check_PROGRAMS = \
 bit375 \
 bitutiltest \
+c11 \
 listener \
 logarr \
 serd \

--- a/libhdt/tests/c11.cpp
+++ b/libhdt/tests/c11.cpp
@@ -1,0 +1,10 @@
+#include <tuple>
+
+int
+main(int argc, char **argv)
+{
+	std::tuple<int, int> t = { 1, 1};
+	std::tuple<int, int> u;
+	t.swap(u);
+	return 0;
+}

--- a/libhdt/tests/c11.cpp
+++ b/libhdt/tests/c11.cpp
@@ -3,7 +3,7 @@
 int
 main(int argc, char **argv)
 {
-	std::tuple<int, int> t = { 1, 1};
+	std::tuple<int, int> t = std::make_tuple(1,1);
 	std::tuple<int, int> u;
 	t.swap(u);
 	return 0;


### PR DESCRIPTION
Remove `make -e` option when building tests