### PR TITLE
Add pkg-config to installation dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ The installation process has the following dependencies:
 
 - [autoconf](https://www.gnu.org/software/autoconf/autoconf.html)
 - [libtool](https://www.gnu.org/software/libtool/)
+- [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/)
 
-The following commands should install both packages:
+The following commands should install all packages:
 
     sudo apt-get update
-    sudo apt-get install autoconf libtool
+    sudo apt-get install autoconf libtool pkg-config
 
 ### Installing
 


### PR DESCRIPTION
A fresh Ubuntu 16.04 gives the following error with the current instructions:

```
configure.ac:10: error: possibly undefined macro: AC_SUBST
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
configure.ac:48: error: possibly undefined macro: AC_DEFINE
autoreconf: /usr/bin/autoconf failed with exit status: 1
```

Installing pkg-config solves this issue.