### PR TITLE
ADDED: Support for setting a base URI.

### DIFF
--- a/libhdt/README.md
+++ b/libhdt/README.md
@@ -21,7 +21,7 @@ $ rdf2hdt [options] <RDF input file> <HDT output file>
 	-c	<configfile>	HDT Config options file
 	-o	<options>	HDT Additional options (option1=value1;option2=value2;...)
 	-f	<format>	Format of the RDF input (ntriples, nquad, n3, turtle, rdfxml)
-	-B	"<base URI>"	Base URI of the dataset.
+	-B	<base-uri>	Base URI of the dataset.
 	-V	Prints the HDT version number.
 	-p	Prints a progress indicator.
 	-v	Verbose output

--- a/libhdt/src/hdt/BasicHDT.cpp
+++ b/libhdt/src/hdt/BasicHDT.cpp
@@ -225,7 +225,7 @@ void BasicHDT::loadDictionary(const char* fileName, const char* baseUri, RDFNota
 		DictionaryLoader dictLoader(dict, &iListener);
 
 		RDFParserCallback *parser = RDFParserCallback::getParserCallback(notation);
-        parser->doParse(fileName, baseUri, notation, true, &dictLoader);
+		parser->doParse(fileName, baseUri, notation, true, &dictLoader);
 		delete parser;
 
 		iListener.setRange(80, 90);
@@ -348,7 +348,7 @@ void BasicHDT::loadTriples(const char* fileName, const char* baseUri, RDFNotatio
 	//cerr << triples->getNumberOfElements() << " triples added in " << st << endl << endl;
 }
 
-void BasicHDT::fillHeader(const string& baseUri) {
+void BasicHDT::fillHeader(const char* baseUri) {
 	string formatNode = "_:format";
 	string dictNode = "_:dictionary";
 	string triplesNode = "_:triples";
@@ -399,22 +399,16 @@ void BasicHDT::fillHeader(const string& baseUri) {
 	header->insert(publicationInfoNode, HDTVocabulary::DUBLIN_CORE_ISSUED, date);
 }
 
-void BasicHDT::loadFromRDF(const char *fileName, string baseUri, RDFNotation notation, ProgressListener *listener)
+void BasicHDT::loadFromRDF(const char *fileName, const char* baseUri, RDFNotation notation, ProgressListener *listener)
 {
 	try {
-		// Make sure that URI starts and ends with <>
-		if(baseUri.at(0)!='<')
-			baseUri = '<'+baseUri;
-		if(baseUri.at(baseUri.length()-1)!='>')
-			baseUri.append(">");
-
 		IntermediateListener iListener(listener);
 
 		iListener.setRange(0,50);
-		loadDictionary(fileName, baseUri.c_str(), notation, &iListener);
+		loadDictionary(fileName, baseUri, notation, &iListener);
 
 		iListener.setRange(50,99);
-		loadTriples(fileName, baseUri.c_str(), notation, &iListener);
+		loadTriples(fileName, baseUri, notation, &iListener);
 
 		fillHeader(baseUri);
 
@@ -637,22 +631,16 @@ void BasicHDT::loadTriplesFromHDTs(const char** fileNames, size_t numFiles, cons
 
 }
 
-void BasicHDT::loadFromSeveralHDT(const char **fileNames, size_t numFiles, string baseUri, ProgressListener *listener)
+void BasicHDT::loadFromSeveralHDT(const char **fileNames, size_t numFiles, const char* baseUri, ProgressListener *listener)
 {
 	try {
-		// Make sure that URI starts and ends with <>
-		if(baseUri.at(0)!='<')
-			baseUri = '<'+baseUri;
-		if(baseUri.at(baseUri.length()-1)!='>')
-			baseUri.append(">");
-
 		IntermediateListener iListener(listener);
 
 		iListener.setRange(0,50);
-		loadDictionaryFromHDTs(fileNames, numFiles, baseUri.c_str(), &iListener);
+		loadDictionaryFromHDTs(fileNames, numFiles, baseUri, &iListener);
 
 		iListener.setRange(50,99);
-		loadTriplesFromHDTs(fileNames, numFiles, baseUri.c_str(), &iListener);
+		loadTriplesFromHDTs(fileNames, numFiles, baseUri, &iListener);
 
 		fillHeader(baseUri);
 

--- a/libhdt/src/hdt/BasicHDT.hpp
+++ b/libhdt/src/hdt/BasicHDT.hpp
@@ -59,7 +59,7 @@ private:
 	void loadDictionaryFromHDTs(const char** fileName, size_t numFiles, const char* baseUri, ProgressListener* listener=NULL);
 	void loadTriplesFromHDTs(const char** fileNames, size_t numFiles, const char* baseUri, ProgressListener* listener=NULL);
 
-	void fillHeader(const string &baseUri);
+	void fillHeader(const char* baseUri);
 
     size_t loadMMap(unsigned char *ptr, unsigned char *ptrMax, ProgressListener *listener=NULL);
     size_t loadMMapIndex(ProgressListener *listener=NULL);
@@ -86,7 +86,7 @@ public:
 	 */
 	Triples *getTriples();
 
-	void loadFromRDF(const char *fileName, string baseUri, RDFNotation notation, ProgressListener *listener = NULL);
+	void loadFromRDF(const char *fileName, const char* baseUri, RDFNotation notation, ProgressListener *listener = NULL);
 
 	/**
 	 * @param input
@@ -100,7 +100,7 @@ public:
 
 	void loadHeader(const char *fileName, ProgressListener *listener);
 
-	void loadFromSeveralHDT(const char **fileNames, size_t numFiles, string baseUri, ProgressListener *listener=NULL);
+	void loadFromSeveralHDT(const char **fileNames, size_t numFiles, const char* baseUri, ProgressListener *listener=NULL);
 
     /**
      * Load an HDT from a file, using memory mapping

--- a/libhdt/src/hdt/BasicModifiableHDT.cpp
+++ b/libhdt/src/hdt/BasicModifiableHDT.cpp
@@ -79,7 +79,7 @@ VarBindingString *BasicModifiableHDT::searchJoin(vector<TripleString> &patterns,
 	throw std::logic_error("Not Implemented");
 }
 
-void BasicModifiableHDT::loadFromRDF(const char *fileName, string baseUri, RDFNotation notation, ProgressListener *listener)
+void BasicModifiableHDT::loadFromRDF(const char *fileName, const char* baseUri, RDFNotation notation, ProgressListener *listener)
 {
 
 }

--- a/libhdt/src/hdt/BasicModifiableHDT.hpp
+++ b/libhdt/src/hdt/BasicModifiableHDT.hpp
@@ -55,7 +55,7 @@ public:
 
 	Triples *getTriples();
 
-	void loadFromRDF(const char *fileName, string baseUri, RDFNotation notation, ProgressListener *listener = NULL);
+	void loadFromRDF(const char *fileName, const char* baseUri, RDFNotation notation, ProgressListener *listener = NULL);
 
 	void loadFromHDT(std::istream &input, ProgressListener *listener = NULL);
 

--- a/libhdt/src/hdt/HDTManager.cpp
+++ b/libhdt/src/hdt/HDTManager.cpp
@@ -75,9 +75,9 @@ HDT *HDTManager::indexedHDT(HDT *hdt, ProgressListener *listener){
 	return bhdt;
 }
 
-HDT *HDTManager::generateHDT(const char *rdfFileName, const char *baseURI, RDFNotation rdfNotation, HDTSpecification &hdtFormat, ProgressListener *listener){
+HDT *HDTManager::generateHDT(const char *rdfFileName, const char* baseUri, RDFNotation rdfNotation, HDTSpecification &hdtFormat, ProgressListener *listener){
 	BasicHDT *hdt = new BasicHDT(hdtFormat);
-	hdt->loadFromRDF(rdfFileName, baseURI, rdfNotation, listener);
+	hdt->loadFromRDF(rdfFileName, baseUri, rdfNotation, listener);
 	return hdt;
 }
 

--- a/libhdt/tests/mergeHDT.cpp
+++ b/libhdt/tests/mergeHDT.cpp
@@ -52,7 +52,7 @@ void help() {
 	cout
 			<< "\t-o\t<options>\tHDT Additional options (option1=value1;option2=value2;...)"
 			<< endl;
-	cout << "\t-B\t\"<base URI>\"\tBase URI of the dataset." << endl;
+	cout << "\t-B\t<base-uri>\tBase URI of the dataset." << endl;
 	//cout << "\t-v\tVerbose output" << endl;
 }
 
@@ -110,7 +110,7 @@ int main(int argc, char **argv) {
 	}
 
 	if (baseUri == "") {
-		baseUri = "<file://" + outputFile + ">";
+		baseUri = "file://" + outputFile;
 	}
 
 #if 0
@@ -136,7 +136,9 @@ int main(int argc, char **argv) {
 		// Read Input Files
 		BasicHDT hdt(spec);
 		hdt.loadFromSeveralHDT((const char **) &argv[optind + 1],
-				argc - optind - 1, baseUri, &progress);
+							   argc-optind-1,
+							   baseUri.c_str(),
+							   &progress);
 
 		hdt.saveToHDT(outputFile.c_str(), &progress);
 

--- a/libhdt/tools/rdf2hdt.cpp
+++ b/libhdt/tools/rdf2hdt.cpp
@@ -52,7 +52,7 @@ void help() {
     cout << "\t-c\t<configfile>\tHDT Config options file" << endl;
     cout << "\t-o\t<options>\tHDT Additional options (option1=value1;option2=value2;...)" << endl;
     cout << "\t-f\t<format>\tFormat of the RDF input (nquads,nq,ntriples,nt,trig,turtle,ttl)" << endl;
-    cout << "\t-B\t\"<base URI>\"\tBase URI of the dataset." << endl;
+    cout << "\t-B\t<base-uri>\tBase URI of the dataset." << endl;
     cout << "\t-V\tPrints the HDT version number." << endl;
     cout << "\t-p\tPrints a progress indicator." << endl;
     cout << "\t-v\tVerbose output" << endl;
@@ -109,9 +109,9 @@ int main(int argc, char **argv) {
                 return 0;
             default:
                 cerr << "ERROR: Unknown option" << endl;
-                
+
                 help();
-                
+
                 return 1;
         }
     }
@@ -146,8 +146,8 @@ int main(int argc, char **argv) {
 		return 1;
 	}
 
-	if(baseUri=="") {
-		baseUri="<file://"+inputFile+">";
+	if (baseUri == "") {
+		baseUri = "file://" + inputFile;
 	}
 
     /**
@@ -157,14 +157,14 @@ int main(int argc, char **argv) {
     if (rdfFormat == "")
     {
         vout << "Input format not given. Guessing from file extension..." << endl;
-        
+
         // Get position of right-most '.' to find file extension.
         size_t dot_position = inputFile.rfind ('.', inputFile.length ());
-        
+
         if (dot_position != string::npos)
             // Extract extension from file name
             rdfFormat = inputFile.substr (dot_position + 1, string::npos);
-        
+
         /**
          * If rdfFormat is still "", it means -f was not specified and the file
          * didn't have any extension. The default format is defined at the top
@@ -176,9 +176,9 @@ int main(int argc, char **argv) {
             vout << "No input format detected: using N-Triples by default." << endl;
         }
     }
-    
+
     // ASSERT: here rdfFormat must be != ""
-    
+
     // Lower-case rdfFormat
     transform (rdfFormat.begin (), rdfFormat.end (), rdfFormat.begin (), ::tolower);
 

--- a/rdf2hdt/rdf2hdt.cpp
+++ b/rdf2hdt/rdf2hdt.cpp
@@ -52,7 +52,7 @@ void help() {
     cout << "\t-c\t<configfile>\tHDT Config options file" << endl;
     cout << "\t-o\t<options>\tHDT Additional options (option1=value1;option2=value2;...)" << endl;
     cout << "\t-f\t<format>\tFormat of the RDF input (nquads,nq,ntriples,nt,trig,turtle,ttl)" << endl;
-    cout << "\t-B\t\"<base URI>\"\tBase URI of the dataset." << endl;
+    cout << "\t-B\t<base-uri>\tBase URI of the dataset." << endl;
     cout << "\t-V\tPrints the HDT version number." << endl;
     //cout << "\t-v\tVerbose output" << endl;
 }
@@ -69,46 +69,6 @@ int main(int argc, char **argv) {
 
     RDFNotation notation = NTRIPLES;
 
-//    int c;
-//    while( (c = getopt(argc,argv,"c:o:vf:B:i:V"))!=-1) {
-//        switch(c) {
-//        case 'c':
-//            configFile = optarg;
-//            cout << "Configfile: " << configFile << endl;
-//            break;
-//        case 'o':
-//            options = optarg;
-//            cout << "Options: " << options << endl;
-//            break;
-//        case 'v':
-//            verbose = true;
-//            break;
-//        case 'f':
-//            rdfFormat = optarg;
-//            cout << "RDF format: " << rdfFormat << endl;
-//            break;
-//        case 'B':
-//            baseUri = optarg;
-//            break;
-//        case 'i':
-//            generateIndex=true;
-//            break;
-//        case 'V':
-//            cout << HDTVersion::get_version_string(".") << endl;
-//            return 0;
-//        default:
-//            cout << "ERROR: Unknown option" << endl;
-//            help();
-//            return 1;
-//        }
-//    }
-
-//    if(argc-optind<2) {
-//        cout << "ERROR: You must supply an input and output" << endl << endl;
-//        help();
-//        return 1;
-//    }
-
     inputFile = argv[1];
     outputFile = argv[2];
 
@@ -124,8 +84,8 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    if(baseUri=="") {
-        baseUri="<file://"+inputFile+">";
+    if (baseUri == "") {
+        baseUri = "file://" + inputFile;
     }
 
     if(rdfFormat!="") {
@@ -161,11 +121,7 @@ int main(int argc, char **argv) {
 
         cout << "HERE: " << endl;
 
-        const char * a = inputFile.c_str();
-        const char * b = baseUri.c_str();
-
         HDT *hdt = HDTManager::generateHDT(inputFile.c_str(), baseUri.c_str(), notation, spec, NULL);
-        //HDT *hdt = HDTManager::generateHDT(inputFile.c_str(), baseUri.c_str(), notation, spec, &progress);
 
         ofstream out;
 


### PR DESCRIPTION
As observed in issue #131, setting the base URI did not work
previously.  As a result, the `-B' flag in the `rdf2hdt' script did
not work either.

This commit adds base URI support by using the Serd API to resolve
relative IRIs while parsing RDF input.

In the old code, base URIs were explicitly rewritten to use Turtle
notation (i.e., using surrounding angular brackets).  Since URI
resolution is now handled by the Serd API, such serialization-specific
reformats are no longer needed and have been removed from the code.

In line with the previous point, the `-B' flag now takes a base URI
argument directly, and does not require surrounding angular brackets.