### PR TITLE
Create an HDT in one pass.

### DIFF
--- a/libhdt/include/Dictionary.hpp
+++ b/libhdt/include/Dictionary.hpp
@@ -132,6 +132,7 @@ public:
     virtual size_t getMaxObjectID()=0;
 
     virtual void import(Dictionary *other, ProgressListener *listener=NULL)=0;
+    virtual void import(Dictionary *other, ModifiableTriples *triplesList, ProgressListener *listener=NULL)=0;
 
     virtual IteratorUCharString *getSubjects()=0;
     virtual IteratorUCharString *getPredicates()=0;

--- a/libhdt/include/HDTEnums.hpp
+++ b/libhdt/include/HDTEnums.hpp
@@ -125,6 +125,11 @@ enum ResultEstimationType {
     EXACT
 };
 
+enum LoaderType {
+    ONE_PASS,
+	TWO_PASS
+};
+
 }
 
 #endif /* HDT_HDTENUMS_HPP_ */

--- a/libhdt/include/HDTManager.hpp
+++ b/libhdt/include/HDTManager.hpp
@@ -89,7 +89,7 @@ public:
 	 * @throws IOException
 	 * @throws ParserException
 	 */
-	static HDT *generateHDT(const char *rdfFileName, const char *baseURI, RDFNotation rdfNotation, HDTSpecification &hdtFormat, ProgressListener *listener=NULL);
+	static HDT *generateHDT(const char *rdfFileName, const char *baseURI, RDFNotation rdfNotation, HDTSpecification &hdtFormat, ProgressListener *listener=NULL, LoaderType LoaderType = LoaderType::TWO_PASS);
 };
 }
 

--- a/libhdt/src/dictionary/FourSectionDictionary.cpp
+++ b/libhdt/src/dictionary/FourSectionDictionary.cpp
@@ -307,6 +307,21 @@ void FourSectionDictionary::import(Dictionary *other, ProgressListener *listener
 	}
 }
 
+void FourSectionDictionary::import(Dictionary *other, ModifiableTriples *triplesList,  ProgressListener *listener) {
+
+	this->import(other, listener);
+
+	// Update all IDs according to new dictionary
+	IteratorTripleID *it = triplesList->searchAll();
+	while(it->hasNext()){
+		TripleID *tripleID = it->next();
+		TripleString *triple = new TripleString();
+		other->tripleIDtoTripleString(*tripleID, *triple);
+		this->tripleStringtoTripleID(*triple, *tripleID);
+		delete triple;
+	}
+}
+
 IteratorUCharString *FourSectionDictionary::getSubjects() {
 	return subjects->listAll();
 }

--- a/libhdt/src/dictionary/FourSectionDictionary.hpp
+++ b/libhdt/src/dictionary/FourSectionDictionary.hpp
@@ -83,6 +83,7 @@ public:
 	size_t load(unsigned char *ptr, unsigned char *ptrMax, ProgressListener *listener=NULL);
 
     void import(Dictionary *other, ProgressListener *listener=NULL);
+	void import(Dictionary *other, ModifiableTriples *triplesList, ProgressListener *listener=NULL);
 
     IteratorUCharString *getSubjects();
     IteratorUCharString *getPredicates();

--- a/libhdt/src/dictionary/KyotoDictionary.cpp
+++ b/libhdt/src/dictionary/KyotoDictionary.cpp
@@ -328,6 +328,10 @@ void KyotoDictionary::import(Dictionary *other, ProgressListener *listener) {
 	throw std::logic_error("Not implemented");
 }
 
+void KyotoDictionary::import(Dictionary *other, ModifiableTriples *triplesList,  ProgressListener *listener) {
+	throw std::logic_error("Not implemented import");
+}
+
 IteratorUCharString *KyotoDictionary::getSubjects() {
 	return new KyotoDictIterator(&this->subjects);
 }

--- a/libhdt/src/dictionary/KyotoDictionary.hpp
+++ b/libhdt/src/dictionary/KyotoDictionary.hpp
@@ -93,6 +93,7 @@ public:
 	size_t load(unsigned char *ptr, unsigned char *ptrMax, ProgressListener *listener=NULL);
 
     void import(Dictionary *other, ProgressListener *listener=NULL);
+	void import(Dictionary *other, ModifiableTriples *triplesList, ProgressListener *listener=NULL);
 
     IteratorUCharString *getSubjects();
     IteratorUCharString *getPredicates();

--- a/libhdt/src/dictionary/LiteralDictionary.cpp
+++ b/libhdt/src/dictionary/LiteralDictionary.cpp
@@ -392,6 +392,10 @@ void LiteralDictionary::import(	Dictionary *other, ProgressListener *listener) {
 	}
 }
 
+void LiteralDictionary::import(Dictionary *other, ModifiableTriples *triplesList,  ProgressListener *listener) {
+	throw std::logic_error("Not implemented import");
+}
+
 IteratorUCharString *LiteralDictionary::getSubjects() {
 	throw std::logic_error("Not implemented");
 }

--- a/libhdt/src/dictionary/LiteralDictionary.hpp
+++ b/libhdt/src/dictionary/LiteralDictionary.hpp
@@ -96,6 +96,7 @@ public:
 	size_t load(unsigned char *ptr, unsigned char *ptrMax, ProgressListener *listener=NULL);
 
     void import(Dictionary *other, ProgressListener *listener=NULL);
+	void import(Dictionary *other, ModifiableTriples *triplesList, ProgressListener *listener=NULL);
 
     IteratorUCharString *getSubjects();
     IteratorUCharString *getPredicates();

--- a/libhdt/src/dictionary/PlainDictionary.cpp
+++ b/libhdt/src/dictionary/PlainDictionary.cpp
@@ -256,6 +256,10 @@ void PlainDictionary::import(Dictionary *other, ProgressListener *listener) {
 	throw std::logic_error("Not implemented import");
 }
 
+void PlainDictionary::import(Dictionary *other, ModifiableTriples *triplesList,  ProgressListener *listener) {
+	throw std::logic_error("Not implemented import");
+}
+
 IteratorUCharString *PlainDictionary::getSubjects() {
 	return new DictIterator(this->subjects);
 }

--- a/libhdt/src/dictionary/PlainDictionary.cpp
+++ b/libhdt/src/dictionary/PlainDictionary.cpp
@@ -316,17 +316,22 @@ size_t PlainDictionary::insert(const std::string & str, TripleComponentRole pos)
 			DictionaryEntry *entry = new DictionaryEntry;
             		entry->str = new char [str.length()+1];
 			strcpy(entry->str, str.c_str());
+			entry->id = subjects.size()+1;
 			sizeStrings += str.length();
 
 			//cout << " Add new subject: " << str << endl;
 			hashSubject[entry->str] = entry;
+			subjects.push_back(entry);
+			return entry->id;
 		} else if(foundSubject) {
 			// Already exists in subjects.
 			//cout << "   existing subject: " << str << endl;
+			return subjectIt->second->id;
 		} else if(foundObject) {
 			// Already exists in objects.
 			//cout << "   existing subject as object: " << str << endl;
 			hashSubject[objectIt->second->str] = objectIt->second;
+			return objectIt->second->id;
 		}
 	} else if(pos==OBJECT) {
 		if(!foundSubject && !foundObject) {
@@ -334,22 +339,24 @@ size_t PlainDictionary::insert(const std::string & str, TripleComponentRole pos)
 			DictionaryEntry *entry = new DictionaryEntry;
             		entry->str = new char [str.length()+1];
 			strcpy(entry->str, str.c_str());
+			entry->id = objects.size()+1;
 			sizeStrings += str.length();
 
 			//cout << " Add new object: " << str << endl;
 			hashObject[entry->str] = entry;
+			objects.push_back(entry);
+			return entry->id;
 		} else if(foundObject) {
 			// Already exists in objects.
 			//cout << "     existing object: " << str << endl;
+			return objectIt->second->id;
 		} else if(foundSubject) {
 			// Already exists in subjects.
 			//cout << "     existing object as subject: " << str << endl;
 			hashObject[subjectIt->second->str] = subjectIt->second;
+			return subjectIt->second->id;
 		}
 	}
-
-	// FIXME: Return inserted index?
-	return 0;
 }
 
 string intToStr(int val) {

--- a/libhdt/src/dictionary/PlainDictionary.hpp
+++ b/libhdt/src/dictionary/PlainDictionary.hpp
@@ -145,6 +145,7 @@ public:
 	size_t load(unsigned char *ptr, unsigned char *ptrMax, ProgressListener *listener=NULL);
 
     void import(Dictionary *other, ProgressListener *listener=NULL);
+	void import(Dictionary *other, ModifiableTriples *triplesList, ProgressListener *listener=NULL);
 
     IteratorUCharString *getSubjects();
     IteratorUCharString *getPredicates();

--- a/libhdt/src/hdt/BasicHDT.cpp
+++ b/libhdt/src/hdt/BasicHDT.cpp
@@ -1006,7 +1006,7 @@ void BasicHDT::loadOnePass(const char* fileName, const char* baseUri, RDFNotatio
 
 		// Convert to final format
 		if (dictionary->getType()!=HDTVocabulary::DICTIONARY_TYPE_PLAIN){
-			dictionary->import(dict);
+			dictionary->import(dict, triplesList);
 			
 			//TODO: Update Ids triples according to new ID.
 

--- a/libhdt/src/hdt/BasicHDT.hpp
+++ b/libhdt/src/hdt/BasicHDT.hpp
@@ -54,6 +54,7 @@ private:
 
 	void loadDictionary(const char *fileName, const char *baseUri, RDFNotation notation, ProgressListener *listener);
 	void loadTriples(const char *fileName, const char *baseUri, RDFNotation notation, ProgressListener *listener);
+	void loadOnePass(const char *fileName, const char *baseUri, RDFNotation notation, ProgressListener *listener);
 
 	void addDictionaryFromHDT(const char *fileName, ModifiableDictionary *dict, ProgressListener *listener=NULL);
 	void loadDictionaryFromHDTs(const char** fileName, size_t numFiles, const char* baseUri, ProgressListener* listener=NULL);
@@ -86,7 +87,7 @@ public:
 	 */
 	Triples *getTriples();
 
-	void loadFromRDF(const char *fileName, string baseUri, RDFNotation notation, ProgressListener *listener = NULL);
+	void loadFromRDF(const char *fileName, string baseUri, RDFNotation notation, ProgressListener *listener = NULL, LoaderType loaderType = LoaderType::TWO_PASS);
 
 	/**
 	 * @param input
@@ -166,6 +167,24 @@ public:
 	void processTriple(const TripleString &triple, unsigned long long pos);
 	uint64_t getSize() {
 		return sizeBytes;
+	}
+};
+
+class OnePassLoader : public RDFCallback {
+private:
+	ModifiableDictionary *dictionary;
+	ModifiableTriples *triples;
+	ProgressListener *listener;
+	unsigned long long count;
+	uint64_t sizeBytes;
+public:
+	OnePassLoader(ModifiableDictionary *dictionary, ModifiableTriples *triples, ProgressListener *listener) : dictionary(dictionary), triples(triples), listener(listener), count(0), sizeBytes(0) { }
+	void processTriple(const TripleString &triple, unsigned long long pos);
+	uint64_t getSize() {
+		return sizeBytes;
+	}
+	inline unsigned long long getCount() {
+		return count;
 	}
 };
 

--- a/libhdt/src/hdt/HDTManager.cpp
+++ b/libhdt/src/hdt/HDTManager.cpp
@@ -75,9 +75,9 @@ HDT *HDTManager::indexedHDT(HDT *hdt, ProgressListener *listener){
 	return bhdt;
 }
 
-HDT *HDTManager::generateHDT(const char *rdfFileName, const char *baseURI, RDFNotation rdfNotation, HDTSpecification &hdtFormat, ProgressListener *listener){
+HDT *HDTManager::generateHDT(const char *rdfFileName, const char *baseURI, RDFNotation rdfNotation, HDTSpecification &hdtFormat, ProgressListener *listener, LoaderType loaderType){
 	BasicHDT *hdt = new BasicHDT(hdtFormat);
-	hdt->loadFromRDF(rdfFileName, baseURI, rdfNotation, listener);
+	hdt->loadFromRDF(rdfFileName, baseURI, rdfNotation, listener, loaderType);
 	return hdt;
 }
 

--- a/libhdt/tools/rdf2hdt.cpp
+++ b/libhdt/tools/rdf2hdt.cpp
@@ -76,7 +76,6 @@ int main(int argc, char **argv) {
      * format it is, we will use NTRIPLES by default.
      */
     RDFNotation notation = NTRIPLES;
-    LoaderType loaderType = TWO_PASS;
 
     int flag;
     while ((flag = getopt (argc, argv, "c:o:vpfl:B:iVh")) != -1)
@@ -211,10 +210,8 @@ int main(int argc, char **argv) {
     vout << "Detected RDF input format: " << rdfFormat << endl;
 
     // Detect loader type 
-    if (lType == "1")
-        loaderType = ONE_PASS;
-
-    vout << "Detected Loader type: " << (loaderType + 1) << endl;
+    LoaderType loaderType = lType == "1" ? ONE_PASS : TWO_PASS;
+    vout << "Detected Loader type: " << (loaderType + 1) << "-pass" << endl;
 
 	// Process
 	HDTSpecification spec(configFile);

--- a/libhdt/tools/rdf2hdt.cpp
+++ b/libhdt/tools/rdf2hdt.cpp
@@ -52,6 +52,7 @@ void help() {
     cout << "\t-c\t<configfile>\tHDT Config options file" << endl;
     cout << "\t-o\t<options>\tHDT Additional options (option1=value1;option2=value2;...)" << endl;
     cout << "\t-f\t<format>\tFormat of the RDF input (nquads,nq,ntriples,nt,trig,turtle,ttl)" << endl;
+    cout << "\t-l\t<loaderType>\tIndicate whether 1 or 2 passes are used to create the HDT (default 2)" << endl;
     cout << "\t-B\t\"<base URI>\"\tBase URI of the dataset." << endl;
     cout << "\t-V\tPrints the HDT version number." << endl;
     cout << "\t-p\tPrints a progress indicator." << endl;
@@ -68,15 +69,17 @@ int main(int argc, char **argv) {
 	string options;
 	string rdfFormat;
 	string baseUri;
+    string lType;
 
     /**
      * Input file format. If no -f is specified and we can't guess which
      * format it is, we will use NTRIPLES by default.
      */
     RDFNotation notation = NTRIPLES;
+    LoaderType loaderType = TWO_PASS;
 
     int flag;
-    while ((flag = getopt (argc, argv, "c:o:vpf:B:iVh")) != -1)
+    while ((flag = getopt (argc, argv, "c:o:vpfl:B:iVh")) != -1)
     {
         switch (flag)
         {
@@ -94,6 +97,9 @@ int main(int argc, char **argv) {
                 break;
             case 'f':
                 rdfFormat = optarg;
+                break;
+            case 'l':
+                lType = optarg;
                 break;
             case 'B':
                 baseUri = optarg;
@@ -204,6 +210,12 @@ int main(int argc, char **argv) {
 
     vout << "Detected RDF input format: " << rdfFormat << endl;
 
+    // Detect loader type 
+    if (lType == "1")
+        loaderType = ONE_PASS;
+
+    vout << "Detected Loader type: " << (loaderType + 1) << endl;
+
 	// Process
 	HDTSpecification spec(configFile);
 
@@ -214,7 +226,7 @@ int main(int argc, char **argv) {
 		StopWatch globalTimer;
 
 		ProgressListener* progress = showProgress ? new StdoutProgressListener() : NULL;
-		HDT *hdt = HDTManager::generateHDT(inputFile.c_str(), baseUri.c_str(), notation, spec, progress);
+		HDT *hdt = HDTManager::generateHDT(inputFile.c_str(), baseUri.c_str(), notation, spec, progress, loaderType);
 
 		ofstream out;
 


### PR DESCRIPTION
This PR is *preliminary* work to fix #47 and is *not at all finished*. However, I hope this starts a discussion that will lead to a possible solution. This is loosely based on what was implemented for Java. 

General approach:
- fix `PlainDictionary.cpp` to return inserted IDs.
- add a `loadOnePass`method to `BasicHDT.cpp` to combine/replace `loadDictionary()`and `loadTriples()` which 
  - builds a temporary dictionary
  - encodes all triples with IDs given by that temp. dictionary
  - create the final dictionary
  - update all triple IDs according to the new dictionary
- update `rdf2hdt.cpp` to supply a 'loader type'

This is not at all performant yet, as my C++ knowledge is also so so. Therefore, I hope to receive enough help and feedback through this PR :)
