### PR TITLE
Fix bin search

### DIFF
--- a/libhdt/src/sequence/AdjacencyList.cpp
+++ b/libhdt/src/sequence/AdjacencyList.cpp
@@ -139,7 +139,7 @@ size_t AdjacencyList::search(size_t element, size_t begin, size_t end) {
 
 size_t AdjacencyList::binSearch(size_t element, size_t begin, size_t end) {
 	while (begin <= end) {
-        size_t mid = {begin+(end-begin)/2};
+        size_t mid {begin+(end-begin)/2};
 
         size_t read = elements->get(mid);
 

--- a/libhdt/src/sequence/AdjacencyList.cpp
+++ b/libhdt/src/sequence/AdjacencyList.cpp
@@ -139,7 +139,7 @@ size_t AdjacencyList::search(size_t element, size_t begin, size_t end) {
 
 size_t AdjacencyList::binSearch(size_t element, size_t begin, size_t end) {
 	while (begin <= end) {
-		int mid = (begin + end) / 2;
+		size_t mid = (begin + end) / 2;
 
         size_t read = elements->get(mid);
 

--- a/libhdt/src/sequence/AdjacencyList.cpp
+++ b/libhdt/src/sequence/AdjacencyList.cpp
@@ -139,7 +139,7 @@ size_t AdjacencyList::search(size_t element, size_t begin, size_t end) {
 
 size_t AdjacencyList::binSearch(size_t element, size_t begin, size_t end) {
 	while (begin <= end) {
-		size_t mid = (begin + end) / 2;
+        size_t mid = {begin+(end-begin)/2};
 
         size_t read = elements->get(mid);
 


### PR DESCRIPTION
@wouterbeek observed that while using hdtSearch upon a very large HDT file, some queries were causing a hang after loading the index and no results were shown. 

This was caused during binary search: the declaration of the middle value is `int`, whereas the begin and end value are `size_t`'s.  For large HDT files this can lead to overflows of the middle and consequently undefined behaviour, like this hang. It could not escape the loop of binary search. 

This should fix the problem. 