### PR TITLE
Change package version in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([libhdt], [1.1.2], [some@email.com], [hdt], [https://github.com/rdfhdt/hdt-cpp])
+AC_INIT([libhdt], [1.3.3], [some@email.com], [hdt], [https://github.com/rdfhdt/hdt-cpp])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build])
 AC_CONFIG_HEADERS([build/config.h])

--- a/libhdt/Makefile.am
+++ b/libhdt/Makefile.am
@@ -107,6 +107,7 @@ src/util/crc8.h\
 src/util/filemap.h\
 src/util/Histogram.h\
 src/util/lru_cache.h\
+src/util/lrucache.hpp\
 src/util/mygetopt.h\
 src/util/propertyutil.h\
 third/gzstream.h\


### PR DESCRIPTION
It updates configure.ac version to the latest released one. Also, it includes a missing file in makefile. Both issues become relevant when creating a distributable release using `make dist` as the version number was incorrect and  `libhdt/src/util/lrucache.hpp` was not included in the package.

Notice that these changes do not affect the versioning scheme implemented in `libhdt/include/HDTVersion.hpp`, which is later used in the executable tools (e.g. `hdtInfo -v`) and when reading indices. I'm not sure if these numbers should be updated or not.