### PR TITLE
options are parsed wrongly

### DIFF
--- a/libhdt/src/hdt/HDTSpecification.cpp
+++ b/libhdt/src/hdt/HDTSpecification.cpp
@@ -48,7 +48,7 @@ void HDTSpecification::setOptions(const std::string& options) {
 	std::istringstream strm(options);
 	std::string singleOption;
 	while(getline(strm, singleOption, ';') ){
-		size_t pos = singleOption.find(':');
+		size_t pos = singleOption.find('=');
 
 		if(pos!=std::string::npos) {
 			std::string property = singleOption.substr(0, pos);


### PR DESCRIPTION
The way the options are parsed is not inline with the documentation:

rdf2hdt [options] <rdf input file> <hdt output file> 
	-h			This help
	-i			Also generate index to solve all triple patterns.
	-c	<configfile>	HDT Config options file
	-o	<options>	HDT Additional options (option1=value1;option2=value2;...)
	-f	<format>	Format of the RDF input (nquads,nq,ntriples,nt,trig,turtle,ttl)
	-B	"<base URI>"	Base URI of the dataset.
	-V	Prints the HDT version number.
	-p	Prints a progress indicator.
	-v	Verbose output

and also not with the java version:

https://github.com/rdfhdt/hdt-java/blob/672fccee8e00b28377b6dd3747df63528635483e/hdt-java-core/src/main/java/org/rdfhdt/hdt/options/HDTOptionsBase.java#L66