### PR TITLE
Upgrade base image gcc:bullseye and create optimized final image stage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.dockerignore
+.git
+.gitignore
+.travis.yml
+Dockerfile
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,4 +52,4 @@ COPY --from=build \
 # Add /usr/local/lib to LD_LIBRARY_PATH.
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH
 
-CMD ["/bin/echo", "Available commands: rdf2hdt hdt2rdf hdtSearch"]
+CMD ["/bin/echo", "Available commands: rdf2hdt hdt2rdf hdtInfo hdtSearch modifyHeader replaceHeader searchHeader"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,20 +4,12 @@ FROM gcc:bullseye as build
 RUN apt-get update && apt-get -y install \
 	build-essential \
 	libraptor2-dev \
-	#libserd-dev \
+	libserd-dev \
 	autoconf \
 	libtool \
 	liblzma-dev \
 	liblzo2-dev \
 	zlib1g-dev
-
-
-# Install more recent serd
-RUN wget https://github.com/drobilla/serd/archive/v0.28.0.tar.gz \
-	&& tar -xvzf *.tar.gz \
-	&& rm *.tar.gz \
-	&& cd serd-* \
-	&& ./waf configure && ./waf && ./waf install
 
 WORKDIR /usr/local/src/hdt-cpp
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY . .
 # Install HDT tools
 RUN ./autogen.sh && ./configure
 RUN make -j4
+RUN make install
 
 # Expose binaries
 ENV PATH /usr/local/src/hdt-cpp/libhdt/tools:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ WORKDIR /usr/local/src/hdt-cpp
 COPY . .
 
 # Install HDT tools
-RUN cd hdt-cpp && ./autogen.sh && ./configure && make -j2
+RUN ./autogen.sh && ./configure
+RUN make -j4
 
 # Expose binaries
 ENV PATH /usr/local/src/hdt-cpp/libhdt/tools:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,34 @@ RUN ./autogen.sh && ./configure
 RUN make -j4
 RUN make install
 
-# Expose binaries
-ENV PATH /usr/local/src/hdt-cpp/libhdt/tools:$PATH
+FROM debian:bullseye-slim
 
-# reset WORKDIR
-WORKDIR /
+# Install runtime dependencies
+RUN apt update; \
+    apt install -y --no-install-recommends \
+		libserd-0-0 \
+	; \
+	rm -rf /var/lib/apt/lists/*;
 
-# Default command
+# Copy in libraries and binaries from build stage.
+COPY --from=build \
+        /usr/local/lib/libcds* \
+		/usr/local/lib/libhdt* \
+		/usr/local/lib/
+COPY --from=build \
+        /usr/local/lib64/libstdc++.* \
+		/usr/local/lib64/
+COPY --from=build \
+		/usr/local/bin/hdt2rdf \
+		/usr/local/bin/hdtInfo \
+		/usr/local/bin/hdtSearch \
+		/usr/local/bin/modifyHeader \
+		/usr/local/bin/rdf2hdt \
+		/usr/local/bin/replaceHeader \
+		/usr/local/bin/searchHeader \
+		/usr/local/bin/
+
+# Add /usr/local/lib to LD_LIBRARY_PATH.
+ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH
+
 CMD ["/bin/echo", "Available commands: rdf2hdt hdt2rdf hdtSearch"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcc:6
+FROM gcc:bullseye as build
 
 WORKDIR /usr/local/src
 COPY . /usr/local/src/hdt-cpp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
 FROM gcc:bullseye as build
 
-# Install dependencies
-RUN apt-get update && apt-get -y install \
-	build-essential \
-	libraptor2-dev \
-	libserd-dev \
-	autoconf \
-	libtool \
-	liblzma-dev \
-	liblzo2-dev \
-	zlib1g-dev
+# Install build dependencies
+RUN apt update; \
+    apt install -y --no-install-recommends \
+	    autoconf \
+		build-essential \
+	    liblzma-dev \
+	    liblzo2-dev \
+	    libraptor2-dev \
+	    libserd-dev \
+	    libtool \
+	    zlib1g-dev \
+    ; \
+    rm -rf /var/lib/apt/lists/*;
 
 WORKDIR /usr/local/src/hdt-cpp
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM gcc:bullseye as build
 
-WORKDIR /usr/local/src
-COPY . /usr/local/src/hdt-cpp/
-
 # Install dependencies
 RUN apt-get update && apt-get -y install \
 	build-essential \
@@ -21,6 +18,9 @@ RUN wget https://github.com/drobilla/serd/archive/v0.28.0.tar.gz \
 	&& rm *.tar.gz \
 	&& cd serd-* \
 	&& ./waf configure && ./waf && ./waf install
+
+WORKDIR /usr/local/src/hdt-cpp
+COPY . .
 
 # Install HDT tools
 RUN cd hdt-cpp && ./autogen.sh && ./configure && make -j2


### PR DESCRIPTION
Bring the Docker image up to date by upgrading the base image from `gcc:6` to `gcc:bullseye` (GCC 11).

Also, optimize the image by creating a final build stage that only has the required libraries and binaries on a `debian:bullseye-slim` base. This trims the image size from about 1.5 GB to 180 MB.

Closes #223.
