### PR TITLE
234 - Removed use of the deprecated C++ register keyword.

### DIFF
--- a/libcds/include/libcdsTrees.h
+++ b/libcds/include/libcdsTrees.h
@@ -78,7 +78,7 @@ namespace cds_utils
 	}
 
 	/* writes e[p..p+len-1] = s, len <= W*/
-	inline void bitwrite (register uint *e, register uint p, register uint len, register uint s) {
+	inline void bitwrite (uint *e, uint p, uint len, uint s) {
 		e += p/W;
 		p %= W;
 		if (len == W) {

--- a/libcds/src/static/coders/huff.cpp
+++ b/libcds/src/static/coders/huff.cpp
@@ -139,8 +139,7 @@ namespace cds_static
 		return H;
 	}
 
-	void bitzero (register uint *e, register uint p,
-	register uint len) {
+	void bitzero (uint *e, uint p, uint len) {
 
 		e += p/W; p %= W;
 		if (p+len >= W) {

--- a/libcds/src/static/suffixtree/RMQ_succinct.cpp
+++ b/libcds/src/static/suffixtree/RMQ_succinct.cpp
@@ -104,7 +104,7 @@ namespace cds_static
 	unsigned int RMQ_succinct::log2fast(unsigned int v) {
 		unsigned int c = 0;		 // c will be lg(v)
 								 // temporaries
-		register unsigned int t, tt;
+		unsigned int t, tt;
 
 		if ((tt = v >> 16))
 			c = (t = v >> 24) ? 24 + LogTable256[t] : 16 + LogTable256[tt & 0xFF];

--- a/libcds/src/static/suffixtree/RMQ_succinct_lcp.cpp
+++ b/libcds/src/static/suffixtree/RMQ_succinct_lcp.cpp
@@ -103,7 +103,7 @@ namespace cds_static
 
 	uint RMQ_succinct_lcp::log2fast(uint v) {
 		uint c = 0;				 // c will be lg(v)
-		register uint t, tt;	 // temporaries
+	        uint t, tt;	 // temporaries
 
 		if ((tt = v >> 16))
 			c = (t = v >> 24) ? 24 + LogTable256[t] : 16 + LogTable256[tt & 0xFF];

--- a/libcds/src/static/suffixtree/factorization.cpp
+++ b/libcds/src/static/suffixtree/factorization.cpp
@@ -58,7 +58,7 @@ namespace cds_static
 		uint levelSizeAux[7]={0,0,0,0,0,0,0};
 		uint cont[7]={0,0,0,0,0,0,0};
 		listLength = l_Length;
-		register uint i;
+		uint i;
 		int j, k;
 		uint value, newvalue;
 		uint bits_BS_len = 0;
@@ -139,7 +139,7 @@ namespace cds_static
 
 	uint factorization::access(uint param) {
 		uint mult=0;
-		register uint j;
+		uint j;
 		uint partialSum=0;
 		uint ini=param-1;
 		uint * bsData = ((BitSequenceRG *)bS)->data;
@@ -173,7 +173,7 @@ namespace cds_static
 
 	uint factorization::access_seq(uint param, size_t *next_pos, bool dir) {
 		uint mult=0;
-		register uint j;
+	        uint j;
 		uint partialSum=0;
 		uint ini=param-1;
 		uint * bsData = ((BitSequenceRG *)bS)->data;

--- a/libcds/src/static/suffixtree/factorization_var.cpp
+++ b/libcds/src/static/suffixtree/factorization_var.cpp
@@ -41,7 +41,7 @@ namespace cds_static
 		uint *cont;
 		uint *contB;
 		listLength = l_Length;
-		register uint i;
+	        uint i;
 		int j, k;
 		uint value, newvalue;
 		uint bits_BS_len = 0;
@@ -171,7 +171,7 @@ namespace cds_static
 
 	uint factorization_var::access(uint param) {
 		uint mult=0;
-		register uint j;
+		uint j;
 		uint partialSum=0;
 		uint ini = param-1;
         unsigned char readByte;
@@ -200,7 +200,7 @@ namespace cds_static
 
 	uint factorization_var::access_seq(uint param, size_t *next_pos, bool dir) {
 		uint mult=0;
-		register uint j;
+		uint j;
 		uint partialSum=0;
 		uint ini = param-1;
         unsigned char readByte;

--- a/libhdt/src/huffman/huff.cpp
+++ b/libhdt/src/huffman/huff.cpp
@@ -162,8 +162,7 @@ namespace URICompressed{
         return H;
     }
 
-    void bitzero (register uint *e, register uint64_t p,
-    register uint len) {
+    void bitzero (uint *e, uint64_t p, uint len) {
 
         e += p/W; p %= W;
         if (p+len >= W) {


### PR DESCRIPTION
Resolved compiler warnings about the use of the register keyword in C++. Fixes #234.