### PR TITLE
Fix building on 32 bit architectures

### DIFF
--- a/libhdt/src/util/bitutil.h
+++ b/libhdt/src/util/bitutil.h
@@ -66,18 +66,18 @@ inline uint32_t wordSelect1(uint64_t value, uint64_t rank) {
 #define SIZET_SIZE (sizeof(size_t)*8)
 
 /** reads bit p from e */
-inline bool bitget(size_t *e, size_t p) {
-	return (e[p/SIZET_SIZE] >> (p%SIZET_SIZE)) & 1;
+inline bool bitget(uint64_t *e, size_t p) {
+	return (e[p/64] >> (p%64)) & 1;
 }
 
 /** sets bit p in e */
-inline void bitset(size_t * e, size_t p) {
-	e[p/SIZET_SIZE] |= (((size_t)1)<<(p%SIZET_SIZE));
+inline void bitset(uint64_t * e, size_t p) {
+	e[p/64] |= (((uint64_t)1)<<(p%64));
 }
 
 /** cleans bit p in e */
-inline void bitclean(size_t * e, size_t p) {
-	e[p/SIZET_SIZE] &= ~(((size_t)1)<<(p%SIZET_SIZE));
+inline void bitclean(uint64_t * e, size_t p) {
+	e[p/64] &= ~(((size_t)1)<<(p%64));
 }
 
 


### PR DESCRIPTION
bitclean war previously implemented for size_t and uint32_t, which overlap on 32 bit architectures. Implementing it for uint32_t and uint64_t might leave the latter unused on 32 bit builds, but is consistent and works on both.

Closes: https://github.com/rdfhdt/hdt-cpp/issues/143

---

This comes from an attempt to build a Debian package for this as described [in the Debian bug tracker](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=749416). In a local test (cross-compiled via `./configure --build=i686-linux-gnu --host=i686-linux-gnu CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32 CXX=clang++`) it produces working binaries (tested with the master branch rdf2hdt and hdt2rdf), but the dictionaries test fails. I did not dig down further there, could be just another case of something being 64-bit specific.

[edit: precision on tested branch]