### PR TITLE
Making the library WebAssembly friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 *.la
 .dirstamp
 
+# Wasm files
+*.wasm
+
 # Executables
 hdt2rdf
 hdtInfo

--- a/libhdt/include/HDTSpecification.hpp
+++ b/libhdt/include/HDTSpecification.hpp
@@ -72,6 +72,13 @@ public:
 	  */
 	const std::string& get(const std::string& key);
 
+
+	/**
+	  * Get the value of a property, or "" if the key is not found.
+	  */
+	const std::string& getOrEmpty(const std::string& key);
+
+
 	/** Set the value of a property */
 	void set(const std::string& key, const std::string& value);
 };

--- a/libhdt/src/bitsequence/BitSequence375.cpp
+++ b/libhdt/src/bitsequence/BitSequence375.cpp
@@ -158,16 +158,20 @@ void BitSequence375::set(const size_t i, bool val) {
 	}
 	if(val) {
 		#ifdef __EMSCRIPTEN__
-		/* EDITED BY @lucafabbian, TODO: check  */
-		fprintf(stderr, "[WARN] Unsafe cast called\n");
+		/* Webassembly size_t differs from the one of
+		other architectures.
+		EDITED BY @lucafabbian, TODO: check  */
+		// fprintf(stderr, "[WARN] Unsafe cast called\n");
 		bitset((uint64_t*) &array[0], i);
 		#else
 		bitset(&array[0], i);
 		#endif
 	} else {
 		#ifdef __EMSCRIPTEN__
-		/* EDITED BY @lucafabbian,  TODO: check */
-		fprintf(stderr, "[WARN] Unsafe cast called\n");
+		/* Webassembly size_t differs from the one of
+		other architectures.
+		EDITED BY @lucafabbian,  TODO: check */
+		// fprintf(stderr, "[WARN] Unsafe cast called\n");
 		bitclean((uint64_t*)&array[0], i);
 		#else
 		bitclean(&array[0], i);
@@ -186,8 +190,10 @@ void BitSequence375::append(bool bit) {
 bool BitSequence375::access(const size_t i) const
 {
 	#ifdef __EMSCRIPTEN__
-	/* EDITED BY @lucafabbian, TODO: check */
-	fprintf(stderr, "[WARN] Unsafe cast called\n");
+	/* Webassembly size_t differs from the one of
+	other architectures.
+	EDITED BY @lucafabbian, TODO: check */
+	//fprintf(stderr, "[WARN] Unsafe cast called\n");
 	return bitget((uint64_t*)array, i);
 	#else
 	return bitget(array, i);

--- a/libhdt/src/bitsequence/BitSequence375.cpp
+++ b/libhdt/src/bitsequence/BitSequence375.cpp
@@ -157,9 +157,21 @@ void BitSequence375::set(const size_t i, bool val) {
         array = &data[0];
 	}
 	if(val) {
+		#ifdef __EMSCRIPTEN__
+		/* EDITED BY @lucafabbian, TODO: check  */
+		fprintf(stderr, "[WARN] Unsafe cast called\n");
+		bitset((uint64_t*) &array[0], i);
+		#else
 		bitset(&array[0], i);
+		#endif
 	} else {
+		#ifdef __EMSCRIPTEN__
+		/* EDITED BY @lucafabbian,  TODO: check */
+		fprintf(stderr, "[WARN] Unsafe cast called\n");
+		bitclean((uint64_t*)&array[0], i);
+		#else
 		bitclean(&array[0], i);
+		#endif
 	}
 
 	numbits = i>=numbits ? i+1 : numbits;
@@ -173,7 +185,13 @@ void BitSequence375::append(bool bit) {
 
 bool BitSequence375::access(const size_t i) const
 {
+	#ifdef __EMSCRIPTEN__
+	/* EDITED BY @lucafabbian, TODO: check */
+	fprintf(stderr, "[WARN] Unsafe cast called\n");
+	return bitget((uint64_t*)array, i);
+	#else
 	return bitget(array, i);
+	#endif
 }
 
 void BitSequence375::save(ostream & out) const

--- a/libhdt/src/dictionary/FourSectionDictionary.cpp
+++ b/libhdt/src/dictionary/FourSectionDictionary.cpp
@@ -56,10 +56,7 @@ FourSectionDictionary::FourSectionDictionary(HDTSpecification & spec) : blocksiz
 	objects = new csd::CSD_PFC();
 	shared = new csd::CSD_PFC();
 
-	string blockSizeStr = "";
-	try{
-		blockSizeStr = spec.get("dict.block.size");
-	}catch(exception& e){}
+	string blockSizeStr = spec.getOrEmpty("dict.block.size");
 
 	if(!blockSizeStr.empty() && (blockSizeStr.find_first_not_of("0123456789") == string::npos))
 	{

--- a/libhdt/src/dictionary/KyotoDictionary.cpp
+++ b/libhdt/src/dictionary/KyotoDictionary.cpp
@@ -50,10 +50,7 @@ KyotoDictionary::KyotoDictionary() {
 }
 
 KyotoDictionary::KyotoDictionary(HDTSpecification &specification) : spec(specification) {
-	string map = "";
-	try{
-		map = spec.get("dictionary.mapping");
-	}catch(exception& e){}
+	string map = spec.getOrEmpty("dictionary.mapping");
 	if(map=="mapping1") {
 		this->mapping = MAPPING1;
 	} else {

--- a/libhdt/src/dictionary/LiteralDictionary.cpp
+++ b/libhdt/src/dictionary/LiteralDictionary.cpp
@@ -57,10 +57,8 @@ LiteralDictionary::LiteralDictionary(HDTSpecification & spec) : blocksize(8) {
 	objectsLiterals = new csd::CSD_FMIndex();
 	shared = new csd::CSD_PFC();
 
-	string blockSizeStr = "";
-	try{
-		blockSizeStr = spec.get("dict.block.size");
-	}catch(exception& e){}
+	string blockSizeStr = spec.getOrEmpty("dict.block.size");
+
 	if (blockSizeStr != "") {
 		blocksize = atoi(blockSizeStr.c_str());
 	}

--- a/libhdt/src/dictionary/PlainDictionary.cpp
+++ b/libhdt/src/dictionary/PlainDictionary.cpp
@@ -55,10 +55,7 @@ PlainDictionary::PlainDictionary() {
 }
 
 PlainDictionary::PlainDictionary(HDTSpecification &specification) : spec(specification) {
-	string map ="";
-	try{
-		map = spec.get("dictionary.mapping");
-	}catch(exception& e){}
+	string map =spec.getOrEmpty("dictionary.mapping");
 	if(map=="mapping1") {
 		this->mapping = MAPPING1;
 	} else {

--- a/libhdt/src/hdt/BasicHDT.cpp
+++ b/libhdt/src/hdt/BasicHDT.cpp
@@ -96,12 +96,8 @@ void BasicHDT::createComponents() {
 
 	// DICTIONARY
 
-	std::string dictType = "";
-	try{
-		dictType = spec.get("dictionary.type");
-	}
-	catch (std::exception& e){
-	}
+	std::string dictType = spec.getOrEmpty("dictionary.type");
+
 
 	if(dictType==HDTVocabulary::DICTIONARY_TYPE_FOUR) {
 		dictionary = new FourSectionDictionary(spec);
@@ -118,11 +114,8 @@ void BasicHDT::createComponents() {
 	}
 
 	// TRIPLES
-	std::string triplesType = "";
-	try{
-		triplesType = spec.get("triples.type");
-	}catch (std::exception& e) {
-	}
+	std::string triplesType = spec.getOrEmpty("triples.type");
+
 	if(triplesType==HDTVocabulary::TRIPLES_TYPE_BITMAP) {
 		triples = new BitmapTriples(spec);
 	} else if(triplesType==HDTVocabulary::TRIPLES_TYPE_PLAIN) {
@@ -299,11 +292,8 @@ void BasicHDT::loadTriples(const char* fileName, const char* baseUri, RDFNotatio
 		triplesList->stopProcessing(&iListener);
 
 		// SORT & Duplicates
-		string ord = "";
-		try{
-			ord = spec.get("triplesOrder");
-		}catch (std::exception& e){
-		}
+		string ord = spec.getOrEmpty("triplesOrder");
+
 		TripleComponentOrder order = parseOrder(
 				ord.c_str());
 		if (order == Unknown) {
@@ -581,12 +571,8 @@ void BasicHDT::loadTriplesFromHDTs(const char** fileNames, size_t numFiles, cons
 		triplesList->stopProcessing(&iListener);
 
 		// SORT & Duplicates
-		string ord = "";
-		try{
-			ord = spec.get("triplesOrder");
-		}
-		catch (std::exception& e){
-		}
+		string ord = spec.getOrEmpty("triplesOrder");
+
 		TripleComponentOrder order = parseOrder(ord.c_str());
 		if (order == Unknown) {
 			order = SPO;

--- a/libhdt/src/hdt/BasicModifiableHDT.cpp
+++ b/libhdt/src/hdt/BasicModifiableHDT.cpp
@@ -28,13 +28,10 @@ BasicModifiableHDT::~BasicModifiableHDT() {
 
 void BasicModifiableHDT::createComponents() {
 	#ifndef __EMSCRIPTEN__
-	try{
+	try {
 		std::string dictType = spec.get("dictionary.type");
 		std::string triplesType = spec.get("triples.type");
-	}
-	 catch (std::exception& e)
-	  {
-	  }
+	}catch (std::exception& e){ }
 
 	#endif
 

--- a/libhdt/src/hdt/BasicModifiableHDT.cpp
+++ b/libhdt/src/hdt/BasicModifiableHDT.cpp
@@ -27,6 +27,7 @@ BasicModifiableHDT::~BasicModifiableHDT() {
 }
 
 void BasicModifiableHDT::createComponents() {
+	#ifndef __EMSCRIPTEN__
 	try{
 		std::string dictType = spec.get("dictionary.type");
 		std::string triplesType = spec.get("triples.type");
@@ -34,6 +35,8 @@ void BasicModifiableHDT::createComponents() {
 	 catch (std::exception& e)
 	  {
 	  }
+
+	#endif
 
 	// FIXME: SELECT
 	header = new PlainHeader();

--- a/libhdt/src/hdt/HDTSpecification.cpp
+++ b/libhdt/src/hdt/HDTSpecification.cpp
@@ -63,6 +63,13 @@ const std::string& HDTSpecification::get(const std::string& key) {
 	return map.at(key);
 }
 
+const std::string emptyString = "";
+
+const std::string& HDTSpecification::getOrEmpty(const std::string& key) {
+	if(map.count(key) == 0) return emptyString;
+	return map.at(key);
+}
+
 void HDTSpecification::set(const std::string& key, const std::string& value) {
 	map[key] = value;
 }

--- a/libhdt/src/hdt/HDTSpecification.cpp
+++ b/libhdt/src/hdt/HDTSpecification.cpp
@@ -66,8 +66,24 @@ const std::string& HDTSpecification::get(const std::string& key) {
 const std::string emptyString = "";
 
 const std::string& HDTSpecification::getOrEmpty(const std::string& key) {
-	if(map.count(key) == 0) return emptyString;
-	return map.at(key);
+
+	/* Webassembly does not play nice with C++ 
+	
+	https://emscripten.org/docs/porting/exceptions.html
+	https://stackoverflow.com/questions/69608789/c-exception-to-exception-less
+	
+	*/
+	#ifdef __EMSCRIPTEN__
+	auto it = map.find(key);
+	return it == map.end() ? emptyString : it->second;
+
+	#else
+	try {
+		return map.at(key);
+	}catch (std::exception& e) {
+		return emptyString;
+	}
+	#endif
 }
 
 void HDTSpecification::set(const std::string& key, const std::string& value) {

--- a/libhdt/src/triples/BitmapTriples.cpp
+++ b/libhdt/src/triples/BitmapTriples.cpp
@@ -44,12 +44,9 @@ namespace hdt {
 #define CHECK_BITMAPTRIPLES_INITIALIZED if(bitmapY==NULL || bitmapZ==NULL){	throw std::runtime_error("Accessing uninitialized BitmapTriples"); }
 
 BitmapTriples::BitmapTriples() : order(SPO) {
-	string typey="";
-	string typez="";
-	try{
-		typey = spec.get("stream.y");
-		typez = spec.get("stream.z");
-	}catch (std::exception& e){}
+	string typey=spec.getOrEmpty("stream.y");
+	string typez=spec.getOrEmpty("stream.z");
+
 	arrayY = IntSequence::getArray(typey);
 	arrayZ = IntSequence::getArray(typez);
 	arrayIndex = NULL;
@@ -61,20 +58,14 @@ BitmapTriples::BitmapTriples() : order(SPO) {
 }
 
 BitmapTriples::BitmapTriples(HDTSpecification &specification) : spec(specification) {
-	std::string orderStr = "";
-	try{
-		orderStr = spec.get("triplesOrder");
-	}catch (std::exception& e){}
+	std::string orderStr = spec.getOrEmpty("triplesOrder");
 
 	order= parseOrder(orderStr.c_str());
 	if(order==Unknown)
 		order = SPO;
-	string typey="";
-	string typez="";
-	try{
-		typey = spec.get("stream.y");
-		typez = spec.get("stream.z");
-	}catch (std::exception& e){}
+	string typey= spec.getOrEmpty("stream.y");
+	string typez= spec.getOrEmpty("stream.z");
+
 	arrayY = IntSequence::getArray(typey);
 	arrayZ = IntSequence::getArray(typez);
 	arrayIndex = NULL;
@@ -852,11 +843,7 @@ size_t BitmapTriples::loadIndex(unsigned char *ptr, unsigned char *ptrMax, Progr
     }
 
     size_t numTriples = controlInformation.getUint("numTriples");
-    std::string typeIndex ="";
-    try{
-    	typeIndex = controlInformation.get("stream.index");
-    }
-    catch(exception &e){}
+    std::string typeIndex = spec.getOrEmpty("stream.index");
 
     if(this->getNumberOfElements()!=numTriples) {
     	// FIXME: Force index regeneration instead of error.

--- a/libhdt/src/triples/PlainTriples.cpp
+++ b/libhdt/src/triples/PlainTriples.cpp
@@ -37,36 +37,26 @@
 namespace hdt {
 
 PlainTriples::PlainTriples() : order(SPO) {
-	string typex="";
-	string typey="";
-	string typez="";
-	try{
-		typex = spec.get("stream.x");
-		typey = spec.get("stream.y");
-		typez = spec.get("stream.z");
-	}catch (std::exception& e){}
+	string typex= spec.getOrEmpty("stream.x");
+	string typey= spec.getOrEmpty("stream.y");
+	string typez= spec.getOrEmpty("stream.z");
+
 	streamX = IntSequence::getArray(typex);
 	streamY = IntSequence::getArray(typey);
 	streamZ = IntSequence::getArray(typez);
 }
 
 PlainTriples::PlainTriples(HDTSpecification &specification) : spec(specification) {
-	std::string orderStr = "";
-	try{
-		orderStr= spec.get("triplesOrder");
-	}catch(exception& e){}
+	std::string orderStr = spec.getOrEmpty("triplesOrder");
+
 	order = parseOrder(orderStr.c_str());
 	if(order==Unknown) {
 			order = SPO;
 	}
-	string typex="";
-	string typey="";
-	string typez="";
-	try{
-		typex = spec.get("stream.x");
-		typey = spec.get("stream.y");
-		typez = spec.get("stream.z");
-	}catch (std::exception& e){}
+	string typex= spec.getOrEmpty("stream.x");
+	string typey= spec.getOrEmpty("stream.y");
+	string typez= spec.getOrEmpty("stream.z");
+
 	streamX = IntSequence::getArray(typex);
 	streamY = IntSequence::getArray(typey);
 	streamZ = IntSequence::getArray(typez);

--- a/libhdt/src/triples/TriplesKyoto.cpp
+++ b/libhdt/src/triples/TriplesKyoto.cpp
@@ -65,10 +65,8 @@ int32_t TriplesKyoto::compare (const char *akbuf, size_t aksiz, const char *bkbu
 
 TriplesKyoto::TriplesKyoto(HDTSpecification &specification) : spec(specification) {
 	unlink("triples.kct");
-	string ord = "";
-	try{
-		ord = spec.get("triplesOrder");
-	}catch(exception& e){}
+	string ord = spec.getOrEmpty("triplesOrder");
+
     order = parseOrder(ord.c_str());
     if(order==Unknown){
         order = SPO;


### PR DESCRIPTION
This pull request aims to make the HDT-cpp library compatible with the emscripten toolchain. In this way, the library may be ported to the to WebAssembly instruction set, which is able to run in the browser.

I was even able to use this fork to build some demos such a turtle to hdt converter (<https://lucafabbian.github.io/hdt-wasm/dist/converter>) and a sparql over hdt file playground (<https://lucafabbian.github.io/hdt-wasm/dist/sparql>).

All changes but refactoring have been guarded by the `#ifdef __EMSCRIPTEN__` directive, and the code should be virtually the same as before on traditional platforms.

I've patched two main things:
- done some casting between pointer sizes
- reduced the use of try/catch. Exceptions are not well-supported in WebAssembly (<https://emscripten.org/docs/porting/exceptions.html>), and the legacy mode has a significant performance overhead.