### PR TITLE
Fix undefined type in StopWatch::toHuman

### DIFF
--- a/libhdt/src/util/StopWatch.cpp
+++ b/libhdt/src/util/StopWatch.cpp
@@ -163,7 +163,7 @@ std::ostream &operator<<(std::ostream &stream, StopWatch &sw) {
 }
 
 std::string StopWatch::toHuman(unsigned long long time) {
-    uint64_t tot_secs = time/1000000;
+        unsigned long long tot_secs = time/1000000;
 
 	unsigned int hours = tot_secs/3600;
 	unsigned int mins = (tot_secs/60) % 60;


### PR DESCRIPTION
Use `unsigned long long` instead of `uint64_t` in StopWatch::toHuman. Since <cstdint> isn't explicitly imported, using `uint64_t` breaks compilation with gcc 13.1.1; it was probably included by another header in the past. Additionally, this makes it consistent with the rest of the function.