### PR TITLE
libhdt/src/util/StopWatch.cpp: add missing <cstdint> ionclude (`gcc-1…

### DIFF
--- a/libhdt/src/util/StopWatch.cpp
+++ b/libhdt/src/util/StopWatch.cpp
@@ -27,6 +27,7 @@
  *
  */
 
+#include <cstdint>
 #include <iostream>
 #include <sstream>
 


### PR DESCRIPTION
…3` fix)

Without the change build on `gcc-13` fails as:

    src/util/StopWatch.cpp: In static member function 'static std::string StopWatch::toHuman(long long unsigned int)':
    src/util/StopWatch.cpp:166:5: error: 'uint64_t' was not declared in this scope
      166 |     uint64_t tot_secs = time/1000000;
          |     ^~~~~~~~
    src/util/StopWatch.cpp:36:1: note: 'uint64_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
       35 | #include "StopWatch.hpp"
      +++ |+#include <cstdint>