### PR TITLE
Update README.md to add dependency on automake. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ dependencies installed:
     Fedora)
   - `brew install autoconf` on macOS/OSX
 
+- [GNU Automake](https://www.gnu.org/software/automake/)
+
+  - `sudo apt install automake` on Debian-based distros (e.g., Ubuntu)
+  - `sudo dnf install automake` on Red Hat-based distros (e.g.,
+    Fedora)
+  - `brew install automake` on macOS/OSX
+
 - [GNU Libtool](https://www.gnu.org/software/libtool/)
 
   - `sudo apt install libtool` on Debian-based distros (e.g., Ubuntu)


### PR DESCRIPTION
Building on a brand new MacOS machine.  After installing documented dependencies using brew, autogen fails with this message:
```
% ./autogen.sh 
./autogen.sh: line 6: aclocal: command not found
Can't exec "aclocal": No such file or directory at /opt/homebrew/Cellar/autoconf/2.72/share/autoconf/Autom4te/FileUtils.pm line 299.
autoreconf: error: aclocal failed with exit status: 2
```
Did a brew install automake and was able to install.  Don't have Linux images to test on but assume that dependencies exists there as well.

